### PR TITLE
Add GitHub MCP golden-path generated example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ CLAUDE.md
 
 # DollhouseMCP (local MCP server state)
 .dollhousemcp/
+
+# Generated package build/install outputs
+generated/*/adapter/node_modules/
+generated/*/adapter/dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub API adapter example migrated from spec repository
   - `adapters/github-api-adapter.md` - Complete GitHub REST API v3 adapter
 - Updated README.md with repository purpose and example index
+- GitHub MCP golden-path generated example artifacts
+  - Added `generated/github-mcp/` capture, schema, adapter, and validation outputs for the first MCP-server-to-MCP-AQL pipeline
+  - Added regeneration and validation documentation for the generated example

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ For **normative protocol specifications**, see the [spec repository](https://git
 |---------|-------------|-----|
 | [GitHub API Adapter](adapters/github-api-adapter.md) | Complete adapter for GitHub REST API v3 | GitHub REST API |
 
+### Generated Golden Paths
+
+| Example | Description | Source |
+|---------|-------------|--------|
+| [GitHub MCP Golden Path](generated/github-mcp/README.md) | End-to-end capture, discovery bundle, generated schema, adapter, and validation artifacts | GitHub MCP server |
+
 ## Structure
 
 Each example adapter is a Markdown file with YAML front matter following the [Adapter Element Type Specification](https://github.com/MCPAQL/spec/blob/develop/docs/adapter/element-type.md). The front matter contains all operation mappings, and the Markdown body provides human-readable documentation.

--- a/generated/github-mcp/README.md
+++ b/generated/github-mcp/README.md
@@ -17,6 +17,12 @@ The generated outputs are intended to be reproducible from the committed config 
 - `capture/warnings.json` is the capture-time warning list emitted during interrogation and normalization.
 - `schema/schema-build-report.json` intentionally carries those warnings forward alongside the schema-builder operation summary so reviewers can see both the original warnings and the reviewed output in one place.
 - `capture/capture-metadata.json` records the upstream GitHub MCP server identity observed during capture. When that upstream server revision changes, this golden-path example should be refreshed.
+- The current saved capture reflects the GitHub MCP server observed on `2026-03-19`, including the newly surfaced `run_secret_scanning` tool. Expect operation counts and warnings to move when the upstream server changes.
+
+## Known Limitations
+
+- The generated adapter keeps a singleton upstream connection and currently expects a restart if that upstream connection is dropped.
+- This example is intentionally saved as a point-in-time artifact. If GitHub changes its MCP surface, the checked-in capture, schema, and validation reports should be regenerated together.
 
 ## Regenerating
 

--- a/generated/github-mcp/README.md
+++ b/generated/github-mcp/README.md
@@ -1,0 +1,12 @@
+# GitHub MCP Golden Path
+
+This directory contains the first end-to-end MCP server -> MCP-AQL adapter pipeline output for the official GitHub MCP server.
+
+Expected artifacts:
+
+- `server-config.json` - source MCP connection config used by `mcpaql-interrogate`
+- `capture/` - raw and normalized discovery artifacts
+- `schema/` - generated MCP-AQL adapter schema and provenance sidecars
+- `adapter/` - generated runnable TypeScript MCP-AQL adapter package
+
+The generated outputs are intended to be reproducible from the committed config plus a valid GitHub token.

--- a/generated/github-mcp/README.md
+++ b/generated/github-mcp/README.md
@@ -8,5 +8,39 @@ Expected artifacts:
 - `capture/` - raw and normalized discovery artifacts
 - `schema/` - generated MCP-AQL adapter schema and provenance sidecars
 - `adapter/` - generated runnable TypeScript MCP-AQL adapter package
+- `validation/` - saved conformance and differential validation reports
 
 The generated outputs are intended to be reproducible from the committed config plus a valid GitHub token.
+
+## Artifact Notes
+
+- `capture/warnings.json` is the capture-time warning list emitted during interrogation and normalization.
+- `schema/schema-build-report.json` intentionally carries those warnings forward alongside the schema-builder operation summary so reviewers can see both the original warnings and the reviewed output in one place.
+- `capture/capture-metadata.json` records the upstream GitHub MCP server identity observed during capture. When that upstream server revision changes, this golden-path example should be refreshed.
+
+## Regenerating
+
+From this directory, rebuild the pipeline with:
+
+```bash
+cd ../../../tools
+npm run build
+
+cd ../adapter-generator
+npm run build
+
+cd ../examples/generated/github-mcp
+export GITHUB_PERSONAL_ACCESS_TOKEN=$(gh auth token)
+
+node ../../../tools/dist/cli.js --config server-config.json --out capture
+node ../../../adapter-generator/dist/schema-cli.js --input capture/discovery-bundle.json --overrides schema-overrides.json --out schema
+node ../../../adapter-generator/dist/generate-cli.js --input schema/adapter-schema.json --provenance schema/adapter-provenance.json --out adapter
+
+cd adapter
+npm install
+npm run build
+cd ..
+
+node ../../../tools/dist/conformance-cli.js --command node --args "[\"dist/server.js\"]" --cwd adapter --schema-root ../../../spec/schemas > validation/conformance-report.json
+node ../../../tools/dist/diff-cli.js --bundle capture/discovery-bundle.json --schema schema/adapter-schema.json --command node --args "[\"dist/server.js\"]" --cwd adapter > validation/differential-report.json
+```

--- a/generated/github-mcp/adapter/README.md
+++ b/generated/github-mcp/adapter/README.md
@@ -1,6 +1,6 @@
-# Github-mcp
+# GitHub MCP
 
-Generated MCP-AQL adapter package for Generated MCP-AQL adapter for the official GitHub MCP server..
+Generated MCP-AQL adapter package for the official GitHub MCP server.
 
 ## Supported Endpoints
 

--- a/generated/github-mcp/adapter/README.md
+++ b/generated/github-mcp/adapter/README.md
@@ -5,12 +5,14 @@ Generated MCP-AQL adapter package for the official GitHub MCP server.
 ## Supported Endpoints
 
 - READ: get_commit, get_copilot_job_status, get_file_contents, get_label, get_latest_release, get_me, get_release_by_tag, get_tag, get_team_members, get_teams, issue_read, list_branches, list_commits, list_issue_types, list_issues, list_pull_requests, list_releases, list_tags, pull_request_read, search_code, search_issues, search_pull_requests, search_repositories, search_users
-- CREATE: add_comment_to_pending_review, add_issue_comment, add_reply_to_pull_request_comment, assign_copilot_to_issue, create_branch, create_pull_request, create_repository, fork_repository
-- UPDATE: create_or_update_file, issue_write, pull_request_review_write, sub_issue_write, update_pull_request, update_pull_request_branch
-- EXECUTE: create_pull_request_with_copilot, merge_pull_request, push_files, request_copilot_review
+- CREATE: add_comment_to_pending_review, add_issue_comment, add_reply_to_pull_request_comment, create_branch, create_pull_request, create_repository, fork_repository
+- UPDATE: assign_copilot_to_issue, create_or_update_file, issue_write, pull_request_review_write, sub_issue_write, update_pull_request, update_pull_request_branch
+- EXECUTE: create_pull_request_with_copilot, merge_pull_request, push_files, request_copilot_review, run_secret_scanning
 - DELETE: delete_file
 
 ## Running
+
+Requires Node.js 20 or newer.
 
 Set `GITHUB_PERSONAL_ACCESS_TOKEN` and run:
 

--- a/generated/github-mcp/adapter/README.md
+++ b/generated/github-mcp/adapter/README.md
@@ -1,0 +1,20 @@
+# Github-mcp
+
+Generated MCP-AQL adapter package for Generated MCP-AQL adapter for the official GitHub MCP server..
+
+## Supported Endpoints
+
+- READ: get_commit, get_copilot_job_status, get_file_contents, get_label, get_latest_release, get_me, get_release_by_tag, get_tag, get_team_members, get_teams, issue_read, list_branches, list_commits, list_issue_types, list_issues, list_pull_requests, list_releases, list_tags, pull_request_read, search_code, search_issues, search_pull_requests, search_repositories, search_users
+- CREATE: add_comment_to_pending_review, add_issue_comment, add_reply_to_pull_request_comment, assign_copilot_to_issue, create_branch, create_pull_request, create_repository, fork_repository
+- UPDATE: create_or_update_file, issue_write, pull_request_review_write, sub_issue_write, update_pull_request, update_pull_request_branch
+- EXECUTE: create_pull_request_with_copilot, merge_pull_request, push_files, request_copilot_review
+- DELETE: delete_file
+
+## Running
+
+Set `GITHUB_PERSONAL_ACCESS_TOKEN` and run:
+
+```bash
+npm install
+npm run start
+```

--- a/generated/github-mcp/adapter/package-lock.json
+++ b/generated/github-mcp/adapter/package-lock.json
@@ -1,0 +1,1717 @@
+{
+  "name": "@mcpaql/generated-github-mcp",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@mcpaql/generated-github-mcp",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.27.1"
+      },
+      "devDependencies": {
+        "@types/node": "^24.3.0",
+        "tsx": "^4.20.5",
+        "typescript": "^5.9.2"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
+      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
+      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
+      "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/generated/github-mcp/adapter/package.json
+++ b/generated/github-mcp/adapter/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@mcpaql/generated-github-mcp",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "tsx src/server.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.27.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.0",
+    "tsx": "^4.20.5",
+    "typescript": "^5.9.2"
+  }
+}

--- a/generated/github-mcp/adapter/package.json
+++ b/generated/github-mcp/adapter/package.json
@@ -2,6 +2,9 @@
   "name": "@mcpaql/generated-github-mcp",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "start": "tsx src/server.ts"

--- a/generated/github-mcp/adapter/src/provenance.json
+++ b/generated/github-mcp/adapter/src/provenance.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-03-13T19:00:32.194Z",
+  "generated_at": "2026-03-13T20:09:00.840Z",
   "source_server_name": "github-mcp-server",
   "source_server_version": "github-mcp-server/remote-9f836f5fe414b6a085717f480c7f23093404340d",
   "source_capture_name": "github-mcp-remote",
@@ -256,7 +256,8 @@
       "endpoint": "EXECUTE",
       "needs_review": true,
       "review_reasons": [
-        "Action-oriented tool classified as EXECUTE conservatively."
+        "Action-oriented tool classified as EXECUTE conservatively.",
+        "push_files can create and update multiple files plus branch history in a single workflow, so the first golden-path adapter keeps it in EXECUTE rather than collapsing it into CREATE or UPDATE."
       ]
     },
     {

--- a/generated/github-mcp/adapter/src/provenance.json
+++ b/generated/github-mcp/adapter/src/provenance.json
@@ -1,0 +1,331 @@
+{
+  "generated_at": "2026-03-13T19:00:32.194Z",
+  "source_server_name": "github-mcp-server",
+  "source_server_version": "github-mcp-server/remote-9f836f5fe414b6a085717f480c7f23093404340d",
+  "source_capture_name": "github-mcp-remote",
+  "warning_count": 37,
+  "operation_count": 43,
+  "operations": [
+    {
+      "source_tool_name": "add_comment_to_pending_review",
+      "operation_name": "add_comment_to_pending_review",
+      "endpoint": "CREATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "add_issue_comment",
+      "operation_name": "add_issue_comment",
+      "endpoint": "CREATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "add_reply_to_pull_request_comment",
+      "operation_name": "add_reply_to_pull_request_comment",
+      "endpoint": "CREATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "assign_copilot_to_issue",
+      "operation_name": "assign_copilot_to_issue",
+      "endpoint": "CREATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "create_branch",
+      "operation_name": "create_branch",
+      "endpoint": "CREATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "create_or_update_file",
+      "operation_name": "create_or_update_file",
+      "endpoint": "UPDATE",
+      "needs_review": true,
+      "review_reasons": [
+        "Tool name spans both create and update semantics.",
+        "Mixed create/update semantics mapped to UPDATE for the first generated adapter."
+      ]
+    },
+    {
+      "source_tool_name": "create_pull_request",
+      "operation_name": "create_pull_request",
+      "endpoint": "CREATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "create_pull_request_with_copilot",
+      "operation_name": "create_pull_request_with_copilot",
+      "endpoint": "EXECUTE",
+      "needs_review": false,
+      "review_reasons": [
+        "Copilot-assisted pull request creation is treated as workflow execution in the first pass."
+      ]
+    },
+    {
+      "source_tool_name": "create_repository",
+      "operation_name": "create_repository",
+      "endpoint": "CREATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "delete_file",
+      "operation_name": "delete_file",
+      "endpoint": "DELETE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "fork_repository",
+      "operation_name": "fork_repository",
+      "endpoint": "CREATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_commit",
+      "operation_name": "get_commit",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_copilot_job_status",
+      "operation_name": "get_copilot_job_status",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_file_contents",
+      "operation_name": "get_file_contents",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_label",
+      "operation_name": "get_label",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_latest_release",
+      "operation_name": "get_latest_release",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_me",
+      "operation_name": "get_me",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_release_by_tag",
+      "operation_name": "get_release_by_tag",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_tag",
+      "operation_name": "get_tag",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_team_members",
+      "operation_name": "get_team_members",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_teams",
+      "operation_name": "get_teams",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "issue_read",
+      "operation_name": "issue_read",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "issue_write",
+      "operation_name": "issue_write",
+      "endpoint": "UPDATE",
+      "needs_review": true,
+      "review_reasons": [
+        "Write suffix is semantically broad and may hide create/update behavior.",
+        "issue_write spans create and update behavior; pinned to UPDATE pending finer-grained decomposition."
+      ]
+    },
+    {
+      "source_tool_name": "list_branches",
+      "operation_name": "list_branches",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "list_commits",
+      "operation_name": "list_commits",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "list_issue_types",
+      "operation_name": "list_issue_types",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "list_issues",
+      "operation_name": "list_issues",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "list_pull_requests",
+      "operation_name": "list_pull_requests",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "list_releases",
+      "operation_name": "list_releases",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "list_tags",
+      "operation_name": "list_tags",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "merge_pull_request",
+      "operation_name": "merge_pull_request",
+      "endpoint": "EXECUTE",
+      "needs_review": true,
+      "review_reasons": [
+        "Action-oriented tool classified as EXECUTE conservatively."
+      ]
+    },
+    {
+      "source_tool_name": "pull_request_read",
+      "operation_name": "pull_request_read",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "pull_request_review_write",
+      "operation_name": "pull_request_review_write",
+      "endpoint": "UPDATE",
+      "needs_review": true,
+      "review_reasons": [
+        "Write suffix is semantically broad and may hide create/update behavior.",
+        "Review-write semantics are treated as UPDATE in the first pass."
+      ]
+    },
+    {
+      "source_tool_name": "push_files",
+      "operation_name": "push_files",
+      "endpoint": "EXECUTE",
+      "needs_review": true,
+      "review_reasons": [
+        "Action-oriented tool classified as EXECUTE conservatively."
+      ]
+    },
+    {
+      "source_tool_name": "request_copilot_review",
+      "operation_name": "request_copilot_review",
+      "endpoint": "EXECUTE",
+      "needs_review": true,
+      "review_reasons": [
+        "Action-oriented tool classified as EXECUTE conservatively."
+      ]
+    },
+    {
+      "source_tool_name": "search_code",
+      "operation_name": "search_code",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "search_issues",
+      "operation_name": "search_issues",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "search_pull_requests",
+      "operation_name": "search_pull_requests",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "search_repositories",
+      "operation_name": "search_repositories",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "search_users",
+      "operation_name": "search_users",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "sub_issue_write",
+      "operation_name": "sub_issue_write",
+      "endpoint": "UPDATE",
+      "needs_review": true,
+      "review_reasons": [
+        "Write suffix is semantically broad and may hide create/update behavior.",
+        "sub_issue_write is treated as UPDATE until the source server exposes narrower tool semantics."
+      ]
+    },
+    {
+      "source_tool_name": "update_pull_request",
+      "operation_name": "update_pull_request",
+      "endpoint": "UPDATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "update_pull_request_branch",
+      "operation_name": "update_pull_request_branch",
+      "endpoint": "UPDATE",
+      "needs_review": false,
+      "review_reasons": []
+    }
+  ]
+}

--- a/generated/github-mcp/adapter/src/provenance.json
+++ b/generated/github-mcp/adapter/src/provenance.json
@@ -1,10 +1,10 @@
 {
-  "generated_at": "2026-03-13T20:09:00.840Z",
+  "generated_at": "2026-03-19T04:08:34.476Z",
   "source_server_name": "github-mcp-server",
-  "source_server_version": "github-mcp-server/remote-9f836f5fe414b6a085717f480c7f23093404340d",
+  "source_server_version": "github-mcp-server/remote-212864f3b76a000b57f4f4f0435df686fc2bbc66",
   "source_capture_name": "github-mcp-remote",
-  "warning_count": 37,
-  "operation_count": 43,
+  "warning_count": 39,
+  "operation_count": 44,
   "operations": [
     {
       "source_tool_name": "add_comment_to_pending_review",
@@ -30,9 +30,11 @@
     {
       "source_tool_name": "assign_copilot_to_issue",
       "operation_name": "assign_copilot_to_issue",
-      "endpoint": "CREATE",
-      "needs_review": false,
-      "review_reasons": []
+      "endpoint": "UPDATE",
+      "needs_review": true,
+      "review_reasons": [
+        "Assignment semantics treated as UPDATE on an existing resource."
+      ]
     },
     {
       "source_tool_name": "create_branch",
@@ -246,7 +248,7 @@
       "endpoint": "UPDATE",
       "needs_review": true,
       "review_reasons": [
-        "Write suffix is semantically broad and may hide create/update behavior.",
+        "Description implies destructive behavior.",
         "Review-write semantics are treated as UPDATE in the first pass."
       ]
     },
@@ -267,6 +269,15 @@
       "needs_review": true,
       "review_reasons": [
         "Action-oriented tool classified as EXECUTE conservatively."
+      ]
+    },
+    {
+      "source_tool_name": "run_secret_scanning",
+      "operation_name": "run_secret_scanning",
+      "endpoint": "EXECUTE",
+      "needs_review": true,
+      "review_reasons": [
+        "Description implies workflow execution."
       ]
     },
     {

--- a/generated/github-mcp/adapter/src/schema.json
+++ b/generated/github-mcp/adapter/src/schema.json
@@ -1,0 +1,1835 @@
+{
+  "name": "github-mcp",
+  "type": "adapter",
+  "version": "0.1.0",
+  "description": "Generated MCP-AQL adapter for the official GitHub MCP server.",
+  "target": {
+    "base_url": "https://api.githubcopilot.com/mcp",
+    "transport": "http",
+    "protocol": "custom",
+    "serialization": "json"
+  },
+  "auth": {
+    "type": "bearer",
+    "header": "Authorization",
+    "prefix": "Bearer ",
+    "token_env": "GITHUB_PERSONAL_ACCESS_TOKEN"
+  },
+  "operations": {
+    "read": [
+      {
+        "name": "get_commit",
+        "maps_to": "tool:get_commit",
+        "description": "Get details for a commit from a GitHub repository",
+        "params": {
+          "include_diff": {
+            "type": "boolean",
+            "description": "Whether to include file diffs and stats in the response. Default is true.",
+            "default": true
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "sha": {
+            "type": "string",
+            "required": true,
+            "description": "Commit SHA, branch name, or tag name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "get_copilot_job_status",
+        "maps_to": "tool:get_copilot_job_status",
+        "description": "Get the status of a GitHub Copilot coding agent job. Use this to check if a previously submitted task has completed and to get the pull request URL once it's created. Provide the job ID (from create_pull_request_with_copilot) or pull request number (from assign_copilot_to_issue), or any pull request you want agent sessions for.",
+        "params": {
+          "id": {
+            "type": "string",
+            "required": true,
+            "description": "Job ID or pull request number"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "get_file_contents",
+        "maps_to": "tool:get_file_contents",
+        "description": "Get the contents of a file or directory from a GitHub repository",
+        "params": {
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner (username or organization)"
+          },
+          "path": {
+            "type": "string",
+            "description": "Path to file/directory",
+            "default": "/"
+          },
+          "ref": {
+            "type": "string",
+            "description": "Accepts optional git refs such as `refs/tags/{tag}`, `refs/heads/{branch}` or `refs/pull/{pr_number}/head`"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "sha": {
+            "type": "string",
+            "description": "Accepts optional commit SHA. If specified, it will be used instead of ref"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "get_label",
+        "maps_to": "tool:get_label",
+        "description": "Get a specific label from a repository.",
+        "params": {
+          "name": {
+            "type": "string",
+            "required": true,
+            "description": "Label name."
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner (username or organization name)"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "get_latest_release",
+        "maps_to": "tool:get_latest_release",
+        "description": "Get the latest release in a GitHub repository",
+        "params": {
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "get_me",
+        "maps_to": "tool:get_me",
+        "description": "Get details of the authenticated GitHub user. Use this when a request is about the user's own profile for GitHub. Or when information is missing to build other tool calls.",
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "get_release_by_tag",
+        "maps_to": "tool:get_release_by_tag",
+        "description": "Get a specific release by its tag name in a GitHub repository",
+        "params": {
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "tag": {
+            "type": "string",
+            "required": true,
+            "description": "Tag name (e.g., 'v1.0.0')"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "get_tag",
+        "maps_to": "tool:get_tag",
+        "description": "Get details about a specific git tag in a GitHub repository",
+        "params": {
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "tag": {
+            "type": "string",
+            "required": true,
+            "description": "Tag name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "get_team_members",
+        "maps_to": "tool:get_team_members",
+        "description": "Get member usernames of a specific team in an organization. Limited to organizations accessible with current credentials",
+        "params": {
+          "org": {
+            "type": "string",
+            "required": true,
+            "description": "Organization login (owner) that contains the team."
+          },
+          "team_slug": {
+            "type": "string",
+            "required": true,
+            "description": "Team slug"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "get_teams",
+        "maps_to": "tool:get_teams",
+        "description": "Get details of the teams the user is a member of. Limited to organizations accessible with current credentials",
+        "params": {
+          "user": {
+            "type": "string",
+            "description": "Username to get teams for. If not provided, uses the authenticated user."
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "issue_read",
+        "maps_to": "tool:issue_read",
+        "description": "Get information about a specific issue in a GitHub repository.",
+        "params": {
+          "issue_number": {
+            "type": "number",
+            "required": true,
+            "description": "The number of the issue"
+          },
+          "method": {
+            "type": "string",
+            "required": true,
+            "description": "The read operation to perform on a single issue.\nOptions are:\n1. get - Get details of a specific issue.\n2. get_comments - Get issue comments.\n3. get_sub_issues - Get sub-issues of the issue.\n4. get_labels - Get labels assigned to the issue.\n",
+            "enum": [
+              "get",
+              "get_comments",
+              "get_sub_issues",
+              "get_labels"
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "The owner of the repository"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "The name of the repository"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "list_branches",
+        "maps_to": "tool:list_branches",
+        "description": "List branches in a GitHub repository",
+        "params": {
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "list_commits",
+        "maps_to": "tool:list_commits",
+        "description": "Get list of commits of a branch in a GitHub repository. Returns at least 30 results per page by default, but can return more if specified using the perPage parameter (up to 100).",
+        "params": {
+          "author": {
+            "type": "string",
+            "description": "Author username or email address to filter commits by"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "sha": {
+            "type": "string",
+            "description": "Commit SHA, branch or tag name to list commits of. If not provided, uses the default branch of the repository. If a commit SHA is provided, will list commits up to that SHA."
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "list_issue_types",
+        "maps_to": "tool:list_issue_types",
+        "description": "List supported issue types for repository owner (organization).",
+        "params": {
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "The organization owner of the repository"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "list_issues",
+        "maps_to": "tool:list_issues",
+        "description": "List issues in a GitHub repository. For pagination, use the 'endCursor' from the previous response's 'pageInfo' in the 'after' parameter.",
+        "params": {
+          "after": {
+            "type": "string",
+            "description": "Cursor for pagination. Use the endCursor from the previous page's PageInfo for GraphQL APIs."
+          },
+          "direction": {
+            "type": "string",
+            "description": "Order direction. If provided, the 'orderBy' also needs to be provided.",
+            "enum": [
+              "ASC",
+              "DESC"
+            ]
+          },
+          "labels": {
+            "type": "array",
+            "description": "Filter by labels"
+          },
+          "order_by": {
+            "type": "string",
+            "description": "Order issues by field. If provided, the 'direction' also needs to be provided.",
+            "enum": [
+              "CREATED_AT",
+              "UPDATED_AT",
+              "COMMENTS"
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "since": {
+            "type": "string",
+            "description": "Filter by date (ISO 8601 timestamp)"
+          },
+          "state": {
+            "type": "string",
+            "description": "Filter by state, by default both open and closed issues are returned when not provided",
+            "enum": [
+              "OPEN",
+              "CLOSED"
+            ]
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "list_pull_requests",
+        "maps_to": "tool:list_pull_requests",
+        "description": "List pull requests in a GitHub repository. If the user specifies an author, then DO NOT use this tool and use the search_pull_requests tool instead.",
+        "params": {
+          "base": {
+            "type": "string",
+            "description": "Filter by base branch"
+          },
+          "direction": {
+            "type": "string",
+            "description": "Sort direction",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "head": {
+            "type": "string",
+            "description": "Filter by head user/org and branch"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "sort": {
+            "type": "string",
+            "description": "Sort by",
+            "enum": [
+              "created",
+              "updated",
+              "popularity",
+              "long-running"
+            ]
+          },
+          "state": {
+            "type": "string",
+            "description": "Filter by state",
+            "enum": [
+              "open",
+              "closed",
+              "all"
+            ]
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "list_releases",
+        "maps_to": "tool:list_releases",
+        "description": "List releases in a GitHub repository",
+        "params": {
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "list_tags",
+        "maps_to": "tool:list_tags",
+        "description": "List git tags in a GitHub repository",
+        "params": {
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "pull_request_read",
+        "maps_to": "tool:pull_request_read",
+        "description": "Get information on a specific pull request in GitHub repository.",
+        "params": {
+          "method": {
+            "type": "string",
+            "required": true,
+            "description": "Action to specify what pull request data needs to be retrieved from GitHub. \nPossible options: \n 1. get - Get details of a specific pull request.\n 2. get_diff - Get the diff of a pull request.\n 3. get_status - Get combined commit status of a head commit in a pull request.\n 4. get_files - Get the list of files changed in a pull request. Use with pagination parameters to control the number of results returned.\n 5. get_review_comments - Get review threads on a pull request. Each thread contains logically grouped review comments made on the same code location during pull request reviews. Returns threads with metadata (isResolved, isOutdated, isCollapsed) and their associated comments. Use cursor-based pagination (perPage, after) to control results.\n 6. get_reviews - Get the reviews on a pull request. When asked for review comments, use get_review_comments method.\n 7. get_comments - Get comments on a pull request. Use this if user doesn't specifically want review comments. Use with pagination parameters to control the number of results returned.\n 8. get_check_runs - Get check runs for the head commit of a pull request. Check runs are the individual CI/CD jobs and checks that run on the PR.\n",
+            "enum": [
+              "get",
+              "get_diff",
+              "get_status",
+              "get_files",
+              "get_review_comments",
+              "get_reviews",
+              "get_comments",
+              "get_check_runs"
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "pull_number": {
+            "type": "number",
+            "required": true,
+            "description": "Pull request number"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "search_code",
+        "maps_to": "tool:search_code",
+        "description": "Fast and precise code search across ALL GitHub repositories using GitHub's native search engine. Best for finding exact symbols, functions, classes, or specific code patterns.",
+        "params": {
+          "order": {
+            "type": "string",
+            "description": "Sort order for results",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "query": {
+            "type": "string",
+            "required": true,
+            "description": "Search query using GitHub's powerful code search syntax. Examples: 'content:Skill language:Java org:github', 'NOT is:archived language:Python OR language:go', 'repo:github/github-mcp-server'. Supports exact matching, language filters, path filters, and more."
+          },
+          "sort": {
+            "type": "string",
+            "description": "Sort field ('indexed' only)"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "search_issues",
+        "maps_to": "tool:search_issues",
+        "description": "Search for issues in GitHub repositories using issues search syntax already scoped to is:issue",
+        "params": {
+          "order": {
+            "type": "string",
+            "description": "Sort order",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "description": "Optional repository owner. If provided with repo, only issues for this repository are listed."
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "query": {
+            "type": "string",
+            "required": true,
+            "description": "Search query using GitHub issues search syntax"
+          },
+          "repo": {
+            "type": "string",
+            "description": "Optional repository name. If provided with owner, only issues for this repository are listed."
+          },
+          "sort": {
+            "type": "string",
+            "description": "Sort field by number of matches of categories, defaults to best match",
+            "enum": [
+              "comments",
+              "reactions",
+              "reactions-+1",
+              "reactions--1",
+              "reactions-smile",
+              "reactions-thinking_face",
+              "reactions-heart",
+              "reactions-tada",
+              "interactions",
+              "created",
+              "updated"
+            ]
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "search_pull_requests",
+        "maps_to": "tool:search_pull_requests",
+        "description": "Search for pull requests in GitHub repositories using issues search syntax already scoped to is:pr",
+        "params": {
+          "order": {
+            "type": "string",
+            "description": "Sort order",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "description": "Optional repository owner. If provided with repo, only pull requests for this repository are listed."
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "query": {
+            "type": "string",
+            "required": true,
+            "description": "Search query using GitHub pull request search syntax"
+          },
+          "repo": {
+            "type": "string",
+            "description": "Optional repository name. If provided with owner, only pull requests for this repository are listed."
+          },
+          "sort": {
+            "type": "string",
+            "description": "Sort field by number of matches of categories, defaults to best match",
+            "enum": [
+              "comments",
+              "reactions",
+              "reactions-+1",
+              "reactions--1",
+              "reactions-smile",
+              "reactions-thinking_face",
+              "reactions-heart",
+              "reactions-tada",
+              "interactions",
+              "created",
+              "updated"
+            ]
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "search_repositories",
+        "maps_to": "tool:search_repositories",
+        "description": "Find GitHub repositories by name, description, readme, topics, or other metadata. Perfect for discovering projects, finding examples, or locating specific repositories across GitHub.",
+        "params": {
+          "minimal_output": {
+            "type": "boolean",
+            "description": "Return minimal repository information (default: true). When false, returns full GitHub API repository objects.",
+            "default": true
+          },
+          "order": {
+            "type": "string",
+            "description": "Sort order",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "query": {
+            "type": "string",
+            "required": true,
+            "description": "Repository search query. Examples: 'machine learning in:name stars:>1000 language:python', 'topic:react', 'user:facebook'. Supports advanced search syntax for precise filtering."
+          },
+          "sort": {
+            "type": "string",
+            "description": "Sort repositories by field, defaults to best match",
+            "enum": [
+              "stars",
+              "forks",
+              "help-wanted-issues",
+              "updated"
+            ]
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "search_users",
+        "maps_to": "tool:search_users",
+        "description": "Find GitHub users by username, real name, or other profile information. Useful for locating developers, contributors, or team members.",
+        "params": {
+          "order": {
+            "type": "string",
+            "description": "Sort order",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "query": {
+            "type": "string",
+            "required": true,
+            "description": "User search query. Examples: 'john smith', 'location:seattle', 'followers:>100'. Search is automatically scoped to type:user."
+          },
+          "sort": {
+            "type": "string",
+            "description": "Sort users by number of followers or repositories, or when the person joined GitHub.",
+            "enum": [
+              "followers",
+              "repositories",
+              "joined"
+            ]
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      }
+    ],
+    "create": [
+      {
+        "name": "add_comment_to_pending_review",
+        "maps_to": "tool:add_comment_to_pending_review",
+        "description": "Add review comment to the requester's latest pending pull request review. A pending review needs to already exist to call this (check with the user if not sure).",
+        "params": {
+          "body": {
+            "type": "string",
+            "required": true,
+            "description": "The text of the review comment"
+          },
+          "line": {
+            "type": "number",
+            "description": "The line of the blob in the pull request diff that the comment applies to. For multi-line comments, the last line of the range"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "path": {
+            "type": "string",
+            "required": true,
+            "description": "The relative path to the file that necessitates a comment"
+          },
+          "pull_number": {
+            "type": "number",
+            "required": true,
+            "description": "Pull request number"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "side": {
+            "type": "string",
+            "description": "The side of the diff to comment on. LEFT indicates the previous state, RIGHT indicates the new state",
+            "enum": [
+              "LEFT",
+              "RIGHT"
+            ]
+          },
+          "start_line": {
+            "type": "number",
+            "description": "For multi-line comments, the first line of the range that the comment applies to"
+          },
+          "start_side": {
+            "type": "string",
+            "description": "For multi-line comments, the starting side of the diff that the comment applies to. LEFT indicates the previous state, RIGHT indicates the new state",
+            "enum": [
+              "LEFT",
+              "RIGHT"
+            ]
+          },
+          "subject_type": {
+            "type": "string",
+            "required": true,
+            "description": "The level at which the comment is targeted",
+            "enum": [
+              "FILE",
+              "LINE"
+            ]
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "add_issue_comment",
+        "maps_to": "tool:add_issue_comment",
+        "description": "Add a comment to a specific issue in a GitHub repository. Use this tool to add comments to pull requests as well (in this case pass pull request number as issue_number), but only if user is not asking specifically to add review comments.",
+        "params": {
+          "body": {
+            "type": "string",
+            "required": true,
+            "description": "Comment content"
+          },
+          "issue_number": {
+            "type": "number",
+            "required": true,
+            "description": "Issue number to comment on"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "add_reply_to_pull_request_comment",
+        "maps_to": "tool:add_reply_to_pull_request_comment",
+        "description": "Add a reply to an existing pull request comment. This creates a new comment that is linked as a reply to the specified comment.",
+        "params": {
+          "body": {
+            "type": "string",
+            "required": true,
+            "description": "The text of the reply"
+          },
+          "comment_id": {
+            "type": "number",
+            "required": true,
+            "description": "The ID of the comment to reply to"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "pull_number": {
+            "type": "number",
+            "required": true,
+            "description": "Pull request number"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "assign_copilot_to_issue",
+        "maps_to": "tool:assign_copilot_to_issue",
+        "description": "Assign Copilot to a specific issue in a GitHub repository.\n\nThis tool can help with the following outcomes:\n- a Pull Request created with source code changes to resolve the issue\n\n\nMore information can be found at:\n- https://docs.github.com/en/copilot/using-github-copilot/using-copilot-coding-agent-to-work-on-tasks/about-assigning-tasks-to-copilot\n",
+        "params": {
+          "base_ref": {
+            "type": "string",
+            "description": "Git reference (e.g., branch) that the agent will start its work from. If not specified, defaults to the repository's default branch"
+          },
+          "custom_instructions": {
+            "type": "string",
+            "description": "Optional custom instructions to guide the agent beyond the issue body. Use this to provide additional context, constraints, or guidance that is not captured in the issue description"
+          },
+          "issue_number": {
+            "type": "number",
+            "required": true,
+            "description": "Issue number"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "create_branch",
+        "maps_to": "tool:create_branch",
+        "description": "Create a new branch in a GitHub repository",
+        "params": {
+          "branch": {
+            "type": "string",
+            "required": true,
+            "description": "Name for new branch"
+          },
+          "from_branch": {
+            "type": "string",
+            "description": "Source branch (defaults to repo default)"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "create_pull_request",
+        "maps_to": "tool:create_pull_request",
+        "description": "Create a new pull request in a GitHub repository.",
+        "params": {
+          "base": {
+            "type": "string",
+            "required": true,
+            "description": "Branch to merge into"
+          },
+          "body": {
+            "type": "string",
+            "description": "PR description"
+          },
+          "draft": {
+            "type": "boolean",
+            "description": "Create as draft PR"
+          },
+          "head": {
+            "type": "string",
+            "required": true,
+            "description": "Branch containing changes"
+          },
+          "maintainer_can_modify": {
+            "type": "boolean",
+            "description": "Allow maintainer edits"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "title": {
+            "type": "string",
+            "required": true,
+            "description": "PR title"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "create_repository",
+        "maps_to": "tool:create_repository",
+        "description": "Create a new GitHub repository in your account or specified organization",
+        "params": {
+          "auto_init": {
+            "type": "boolean",
+            "description": "Initialize with README"
+          },
+          "description": {
+            "type": "string",
+            "description": "Repository description"
+          },
+          "name": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "organization": {
+            "type": "string",
+            "description": "Organization to create the repository in (omit to create in your personal account)"
+          },
+          "private": {
+            "type": "boolean",
+            "description": "Whether repo should be private"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "fork_repository",
+        "maps_to": "tool:fork_repository",
+        "description": "Fork a GitHub repository to your account or specified organization",
+        "params": {
+          "organization": {
+            "type": "string",
+            "description": "Organization to fork to"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      }
+    ],
+    "update": [
+      {
+        "name": "create_or_update_file",
+        "maps_to": "tool:create_or_update_file",
+        "description": "Create or update a single file in a GitHub repository. \nIf updating, you should provide the SHA of the file you want to update. Use this tool to create or update a file in a GitHub repository remotely; do not use it for local file operations.\n\nIn order to obtain the SHA of original file version before updating, use the following git command:\ngit rev-parse <branch>:<path to file>\n\nSHA MUST be provided for existing file updates.\n",
+        "params": {
+          "branch": {
+            "type": "string",
+            "required": true,
+            "description": "Branch to create/update the file in"
+          },
+          "content": {
+            "type": "string",
+            "required": true,
+            "description": "Content of the file"
+          },
+          "message": {
+            "type": "string",
+            "required": true,
+            "description": "Commit message"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner (username or organization)"
+          },
+          "path": {
+            "type": "string",
+            "required": true,
+            "description": "Path where to create/update the file"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "sha": {
+            "type": "string",
+            "description": "The blob SHA of the file being replaced. Required if the file already exists."
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "issue_write",
+        "maps_to": "tool:issue_write",
+        "description": "Create a new or update an existing issue in a GitHub repository.",
+        "params": {
+          "assignees": {
+            "type": "array",
+            "description": "Usernames to assign to this issue"
+          },
+          "body": {
+            "type": "string",
+            "description": "Issue body content"
+          },
+          "duplicate_of": {
+            "type": "number",
+            "description": "Issue number that this issue is a duplicate of. Only used when state_reason is 'duplicate'."
+          },
+          "issue_number": {
+            "type": "number",
+            "description": "Issue number to update"
+          },
+          "labels": {
+            "type": "array",
+            "description": "Labels to apply to this issue"
+          },
+          "method": {
+            "type": "string",
+            "required": true,
+            "description": "Write operation to perform on a single issue.\nOptions are:\n- 'create' - creates a new issue.\n- 'update' - updates an existing issue.\n",
+            "enum": [
+              "create",
+              "update"
+            ]
+          },
+          "milestone": {
+            "type": "number",
+            "description": "Milestone number"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "state": {
+            "type": "string",
+            "description": "New state",
+            "enum": [
+              "open",
+              "closed"
+            ]
+          },
+          "state_reason": {
+            "type": "string",
+            "description": "Reason for the state change. Ignored unless state is changed.",
+            "enum": [
+              "completed",
+              "not_planned",
+              "duplicate"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "description": "Issue title"
+          },
+          "type": {
+            "type": "string",
+            "description": "Type of this issue. Only use if the repository has issue types configured. Use list_issue_types tool to get valid type values for the organization. If the repository doesn't support issue types, omit this parameter."
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "pull_request_review_write",
+        "maps_to": "tool:pull_request_review_write",
+        "description": "Create and/or submit, delete review of a pull request.\n\nAvailable methods:\n- create: Create a new review of a pull request. If \"event\" parameter is provided, the review is submitted. If \"event\" is omitted, a pending review is created.\n- submit_pending: Submit an existing pending review of a pull request. This requires that a pending review exists for the current user on the specified pull request. The \"body\" and \"event\" parameters are used when submitting the review.\n- delete_pending: Delete an existing pending review of a pull request. This requires that a pending review exists for the current user on the specified pull request.\n",
+        "params": {
+          "body": {
+            "type": "string",
+            "description": "Review comment text"
+          },
+          "commit_id": {
+            "type": "string",
+            "description": "SHA of commit to review"
+          },
+          "event": {
+            "type": "string",
+            "description": "Review action to perform.",
+            "enum": [
+              "APPROVE",
+              "REQUEST_CHANGES",
+              "COMMENT"
+            ]
+          },
+          "method": {
+            "type": "string",
+            "required": true,
+            "description": "The write operation to perform on pull request review.",
+            "enum": [
+              "create",
+              "submit_pending",
+              "delete_pending"
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "pull_number": {
+            "type": "number",
+            "required": true,
+            "description": "Pull request number"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "sub_issue_write",
+        "maps_to": "tool:sub_issue_write",
+        "description": "Add a sub-issue to a parent issue in a GitHub repository.",
+        "params": {
+          "after_id": {
+            "type": "number",
+            "description": "The ID of the sub-issue to be prioritized after (either after_id OR before_id should be specified)"
+          },
+          "before_id": {
+            "type": "number",
+            "description": "The ID of the sub-issue to be prioritized before (either after_id OR before_id should be specified)"
+          },
+          "issue_number": {
+            "type": "number",
+            "required": true,
+            "description": "The number of the parent issue"
+          },
+          "method": {
+            "type": "string",
+            "required": true,
+            "description": "The action to perform on a single sub-issue\nOptions are:\n- 'add' - add a sub-issue to a parent issue in a GitHub repository.\n- 'remove' - remove a sub-issue from a parent issue in a GitHub repository.\n- 'reprioritize' - change the order of sub-issues within a parent issue in a GitHub repository. Use either 'after_id' or 'before_id' to specify the new position.\n\t\t\t\t"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "replace_parent": {
+            "type": "boolean",
+            "description": "When true, replaces the sub-issue's current parent issue. Use with 'add' method only."
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "sub_issue_id": {
+            "type": "number",
+            "required": true,
+            "description": "The ID of the sub-issue to add. ID is not the same as issue number"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "update_pull_request",
+        "maps_to": "tool:update_pull_request",
+        "description": "Update an existing pull request in a GitHub repository.",
+        "params": {
+          "base": {
+            "type": "string",
+            "description": "New base branch name"
+          },
+          "body": {
+            "type": "string",
+            "description": "New description"
+          },
+          "draft": {
+            "type": "boolean",
+            "description": "Mark pull request as draft (true) or ready for review (false)"
+          },
+          "maintainer_can_modify": {
+            "type": "boolean",
+            "description": "Allow maintainer edits"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "pull_number": {
+            "type": "number",
+            "required": true,
+            "description": "Pull request number to update"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "reviewers": {
+            "type": "array",
+            "description": "GitHub usernames to request reviews from"
+          },
+          "state": {
+            "type": "string",
+            "description": "New state",
+            "enum": [
+              "open",
+              "closed"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "description": "New title"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "update_pull_request_branch",
+        "maps_to": "tool:update_pull_request_branch",
+        "description": "Update the branch of a pull request with the latest changes from the base branch.",
+        "params": {
+          "expected_head_sha": {
+            "type": "string",
+            "description": "The expected SHA of the pull request's HEAD ref"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "pull_number": {
+            "type": "number",
+            "required": true,
+            "description": "Pull request number"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      }
+    ],
+    "execute": [
+      {
+        "name": "create_pull_request_with_copilot",
+        "maps_to": "tool:create_pull_request_with_copilot",
+        "description": "Delegate a task to GitHub Copilot coding agent to perform in the background. The agent will create a pull request with the implementation. You should use this tool if the user asks to create a pull request to perform a specific task, or if the user asks Copilot to do something.",
+        "params": {
+          "base_ref": {
+            "type": "string",
+            "description": "Git reference (e.g., branch) that the agent will start its work from. If not specified, defaults to the repository's default branch"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner. You can guess the owner, but confirm it with the user before proceeding."
+          },
+          "problem_statement": {
+            "type": "string",
+            "required": true,
+            "description": "Detailed description of the task to be performed (e.g., 'Implement a feature that does X', 'Fix bug Y', etc.)"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name. You can guess the repository name, but confirm it with the user before proceeding."
+          },
+          "title": {
+            "type": "string",
+            "required": true,
+            "description": "Title for the pull request that will be created"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": true
+      },
+      {
+        "name": "merge_pull_request",
+        "maps_to": "tool:merge_pull_request",
+        "description": "Merge a pull request in a GitHub repository.",
+        "params": {
+          "commit_message": {
+            "type": "string",
+            "description": "Extra detail for merge commit"
+          },
+          "commit_title": {
+            "type": "string",
+            "description": "Title for merge commit"
+          },
+          "merge_method": {
+            "type": "string",
+            "description": "Merge method",
+            "enum": [
+              "merge",
+              "squash",
+              "rebase"
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "pull_number": {
+            "type": "number",
+            "required": true,
+            "description": "Pull request number"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "dangerous",
+        "requires_confirmation": true,
+        "non_idempotent": true
+      },
+      {
+        "name": "push_files",
+        "maps_to": "tool:push_files",
+        "description": "Push multiple files to a GitHub repository in a single commit",
+        "params": {
+          "branch": {
+            "type": "string",
+            "required": true,
+            "description": "Branch to push to"
+          },
+          "files": {
+            "type": "array",
+            "required": true,
+            "description": "Array of file objects to push, each object with path (string) and content (string)"
+          },
+          "message": {
+            "type": "string",
+            "required": true,
+            "description": "Commit message"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "dangerous",
+        "requires_confirmation": true,
+        "non_idempotent": true
+      },
+      {
+        "name": "request_copilot_review",
+        "maps_to": "tool:request_copilot_review",
+        "description": "Request a GitHub Copilot code review for a pull request. Use this for automated feedback on pull requests, usually before requesting a human reviewer.",
+        "params": {
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "pull_number": {
+            "type": "number",
+            "required": true,
+            "description": "Pull request number"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "dangerous",
+        "requires_confirmation": true,
+        "non_idempotent": true
+      }
+    ],
+    "delete": [
+      {
+        "name": "delete_file",
+        "maps_to": "tool:delete_file",
+        "description": "Delete a file from a GitHub repository",
+        "params": {
+          "branch": {
+            "type": "string",
+            "required": true,
+            "description": "Branch to delete the file from"
+          },
+          "message": {
+            "type": "string",
+            "required": true,
+            "description": "Commit message"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner (username or organization)"
+          },
+          "path": {
+            "type": "string",
+            "required": true,
+            "description": "Path to the file to delete"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "destructive",
+        "requires_confirmation": true,
+        "non_idempotent": false
+      }
+    ]
+  }
+}

--- a/generated/github-mcp/adapter/src/schema.json
+++ b/generated/github-mcp/adapter/src/schema.json
@@ -1119,43 +1119,6 @@
         "non_idempotent": false
       },
       {
-        "name": "assign_copilot_to_issue",
-        "maps_to": "tool:assign_copilot_to_issue",
-        "description": "Assign Copilot to a specific issue in a GitHub repository.\n\nThis tool can help with the following outcomes:\n- a Pull Request created with source code changes to resolve the issue\n\n\nMore information can be found at:\n- https://docs.github.com/en/copilot/using-github-copilot/using-copilot-coding-agent-to-work-on-tasks/about-assigning-tasks-to-copilot\n",
-        "params": {
-          "base_ref": {
-            "type": "string",
-            "description": "Git reference (e.g., branch) that the agent will start its work from. If not specified, defaults to the repository's default branch"
-          },
-          "custom_instructions": {
-            "type": "string",
-            "description": "Optional custom instructions to guide the agent beyond the issue body. Use this to provide additional context, constraints, or guidance that is not captured in the issue description"
-          },
-          "issue_number": {
-            "type": "number",
-            "required": true,
-            "description": "Issue number"
-          },
-          "owner": {
-            "type": "string",
-            "required": true,
-            "description": "Repository owner"
-          },
-          "repo": {
-            "type": "string",
-            "required": true,
-            "description": "Repository name"
-          }
-        },
-        "response": {
-          "type": "object",
-          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
-        },
-        "danger_level": "reversible",
-        "requires_confirmation": false,
-        "non_idempotent": false
-      },
-      {
         "name": "create_branch",
         "maps_to": "tool:create_branch",
         "description": "Create a new branch in a GitHub repository",
@@ -1304,6 +1267,43 @@
       }
     ],
     "update": [
+      {
+        "name": "assign_copilot_to_issue",
+        "maps_to": "tool:assign_copilot_to_issue",
+        "description": "Assign Copilot to a specific issue in a GitHub repository.\n\nThis tool can help with the following outcomes:\n- a Pull Request created with source code changes to resolve the issue\n\n\nMore information can be found at:\n- https://docs.github.com/en/copilot/using-github-copilot/using-copilot-coding-agent-to-work-on-tasks/about-assigning-tasks-to-copilot\n",
+        "params": {
+          "base_ref": {
+            "type": "string",
+            "description": "Git reference (e.g., branch) that the agent will start its work from. If not specified, defaults to the repository's default branch"
+          },
+          "custom_instructions": {
+            "type": "string",
+            "description": "Optional custom instructions to guide the agent beyond the issue body. Use this to provide additional context, constraints, or guidance that is not captured in the issue description"
+          },
+          "issue_number": {
+            "type": "number",
+            "required": true,
+            "description": "Issue number"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
       {
         "name": "create_or_update_file",
         "maps_to": "tool:create_or_update_file",
@@ -1486,8 +1486,8 @@
           "type": "object",
           "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
         },
-        "danger_level": "reversible",
-        "requires_confirmation": false,
+        "danger_level": "destructive",
+        "requires_confirmation": true,
         "non_idempotent": false
       },
       {
@@ -1774,6 +1774,35 @@
             "type": "number",
             "required": true,
             "description": "Pull request number"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "dangerous",
+        "requires_confirmation": true,
+        "non_idempotent": true
+      },
+      {
+        "name": "run_secret_scanning",
+        "maps_to": "tool:run_secret_scanning",
+        "description": "Scan files, content, or recent changes for secrets such as API keys, passwords, tokens, and credentials.\n\nThis tool is intended for targeted scans of specific files, snippets, or diffs provided directly as content. It accepts file contents or diffs and returns detected secrets with their locations and related secret scanning metadata. Content must not be empty. For full repository scanning, other mechanisms are available.\n\nCaveats:\n\n- Only files within the codebase should be scanned. Files outside of the codebase should not be sent.\n- Files listed in .gitignore should be skipped.",
+        "params": {
+          "files": {
+            "type": "array",
+            "required": true,
+            "description": "Array of file contents, snippets, or diff hunks to scan for secrets. These must be raw contents, not repository file paths."
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
           },
           "repo": {
             "type": "string",

--- a/generated/github-mcp/adapter/src/server.ts
+++ b/generated/github-mcp/adapter/src/server.ts
@@ -1,18 +1,33 @@
-// @ts-nocheck
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import type {
+  CallToolRequest,
+  CallToolResult,
+  ListToolsResult,
+} from "@modelcontextprotocol/sdk/types.js";
 import schema from "./schema.json" with { type: "json" };
 import provenance from "./provenance.json" with { type: "json" };
 
-const TOOL_BY_OPERATION = new Map(
-  Object.entries(schema.operations)
-    .flatMap(([endpoint, operations]) => (operations ?? []).map((operation) => [operation.name, { endpoint: endpoint.toUpperCase(), definition: operation }]))
-);
+type SchemaOperations = typeof schema.operations;
+type EndpointKey = keyof SchemaOperations;
+type EndpointName = Uppercase<EndpointKey>;
+type OperationDefinition = NonNullable<SchemaOperations[EndpointKey]>[number];
+type OperationIndexEntry = {
+  endpoint: EndpointName;
+  definition: OperationDefinition;
+};
+type OperationArguments = Record<string, unknown> & {
+  operation?: unknown;
+  params?: unknown;
+};
 
-const TOOL_NAME_BY_ENDPOINT = {
+const TOOL_NAME_BY_ENDPOINT: Record<EndpointName, string> = {
   CREATE: "mcp_aql_create",
   READ: "mcp_aql_read",
   UPDATE: "mcp_aql_update",
@@ -20,12 +35,26 @@ const TOOL_NAME_BY_ENDPOINT = {
   EXECUTE: "mcp_aql_execute",
 };
 
-/** @type {Client | undefined} */
-let upstreamClient;
-/** @type {StreamableHTTPClientTransport | undefined} */
-let upstreamTransport;
+const TOOL_BY_OPERATION = new Map<string, OperationIndexEntry>();
+for (const [endpoint, operations] of Object.entries(schema.operations) as Array<[EndpointKey, OperationDefinition[] | undefined]>) {
+  for (const operation of operations ?? []) {
+    TOOL_BY_OPERATION.set(operation.name, {
+      endpoint: endpoint.toUpperCase() as EndpointName,
+      definition: operation,
+    });
+  }
+}
 
-function resolveToken() {
+let upstreamClient: Client | undefined;
+let upstreamTransport: StreamableHTTPClientTransport | undefined;
+
+function textResult(payload: unknown): CallToolResult {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+  };
+}
+
+function resolveToken(): string {
   const configured = schema.auth?.token_env;
   if (configured && process.env[configured]) {
     return process.env[configured];
@@ -34,7 +63,7 @@ function resolveToken() {
   throw new Error(`Missing upstream bearer token in env var '${configured ?? "GITHUB_PERSONAL_ACCESS_TOKEN"}'.`);
 }
 
-async function getUpstreamClient() {
+async function getUpstreamClient(): Promise<Client> {
   if (upstreamClient) {
     return upstreamClient;
   }
@@ -53,12 +82,12 @@ async function getUpstreamClient() {
   return upstreamClient;
 }
 
-function resolveParams(args) {
-  if (args && typeof args.params === "object" && args.params !== null) {
-    return args.params;
+function resolveParams(args: OperationArguments | undefined): Record<string, unknown> {
+  if (args && typeof args.params === "object" && args.params !== null && !Array.isArray(args.params)) {
+    return args.params as Record<string, unknown>;
   }
 
-  if (!args || typeof args !== "object") {
+  if (!args) {
     return {};
   }
 
@@ -67,7 +96,7 @@ function resolveParams(args) {
   return clone;
 }
 
-function buildToolDescription(endpoint, operations) {
+function buildToolDescription(endpoint: EndpointName, operations: OperationDefinition[]): string {
   const names = operations.map((operation) => operation.name).join(", ");
   const quickStart = endpoint === "READ"
     ? '{ operation: "introspect", params: { query: "operations" } }'
@@ -84,7 +113,7 @@ function buildToolDescription(endpoint, operations) {
 }
 
 function buildIntrospectionOperations() {
-  const operations = [
+  const operations: Array<{ name: string; endpoint: EndpointName; description: string }> = [
     {
       name: "introspect",
       endpoint: "READ",
@@ -92,11 +121,11 @@ function buildIntrospectionOperations() {
     },
   ];
 
-  for (const [endpoint, entries] of Object.entries(schema.operations)) {
+  for (const [endpoint, entries] of Object.entries(schema.operations) as Array<[EndpointKey, OperationDefinition[] | undefined]>) {
     for (const operation of entries ?? []) {
       operations.push({
         name: operation.name,
-        endpoint: endpoint.toUpperCase(),
+        endpoint: endpoint.toUpperCase() as EndpointName,
         description: operation.description,
       });
     }
@@ -105,7 +134,7 @@ function buildIntrospectionOperations() {
   return operations;
 }
 
-function buildOperationDetails(name) {
+function buildOperationDetails(name: string) {
   if (name === "introspect") {
     return {
       name: "introspect",
@@ -180,7 +209,7 @@ function buildTypeList() {
   ];
 }
 
-function buildTypeDetails(name) {
+function buildTypeDetails(name: string) {
   if (name !== "WrappedToolResult") {
     return null;
   }
@@ -198,18 +227,21 @@ function buildTypeDetails(name) {
   };
 }
 
-function buildIntrospection(params) {
-  if (params.query === "operations") {
-    if (params.name) {
-      const operation = buildOperationDetails(params.name);
+function buildIntrospection(params: Record<string, unknown>) {
+  const query = typeof params.query === "string" ? params.query : undefined;
+  const name = typeof params.name === "string" ? params.name : undefined;
+
+  if (query === "operations") {
+    if (name) {
+      const operation = buildOperationDetails(name);
       if (!operation) {
-        return { success: false, error: { code: "NOT_FOUND_OPERATION", message: `Unknown operation: ${params.name}` } };
+        return { success: false, error: { code: "NOT_FOUND_OPERATION", message: `Unknown operation: ${name}` } };
       }
 
-    return {
-      success: true,
-      data: { operation },
-    };
+      return {
+        success: true,
+        data: { operation },
+      };
     }
 
     return {
@@ -224,11 +256,11 @@ function buildIntrospection(params) {
     };
   }
 
-  if (params.query === "types") {
-    if (params.name) {
-      const type = buildTypeDetails(params.name);
+  if (query === "types") {
+    if (name) {
+      const type = buildTypeDetails(name);
       if (!type) {
-        return { success: false, error: { code: "NOT_FOUND_TYPE", message: `Unknown type: ${params.name}` } };
+        return { success: false, error: { code: "NOT_FOUND_TYPE", message: `Unknown type: ${name}` } };
       }
 
       return {
@@ -247,12 +279,12 @@ function buildIntrospection(params) {
     success: false,
     error: {
       code: "VALIDATION_INVALID_QUERY",
-      message: `Unknown introspection query: ${params.query}`,
+      message: `Unknown introspection query: ${String(params.query)}`,
     },
   };
 }
 
-async function proxyOperation(operationName, params) {
+async function proxyOperation(operationName: string, params: Record<string, unknown>) {
   const item = TOOL_BY_OPERATION.get(operationName);
   if (!item) {
     return {
@@ -304,12 +336,12 @@ const server = new Server(
   { capabilities: { tools: {} } },
 );
 
-server.setRequestHandler(ListToolsRequestSchema as any, async () => ({
-  tools: Object.entries(schema.operations)
+server.setRequestHandler(ListToolsRequestSchema, async (): Promise<ListToolsResult> => ({
+  tools: (Object.entries(schema.operations) as Array<[EndpointKey, OperationDefinition[] | undefined]>)
     .filter(([, operations]) => Array.isArray(operations) && operations.length > 0)
     .map(([endpoint, operations]) => ({
-      name: TOOL_NAME_BY_ENDPOINT[endpoint.toUpperCase()],
-      description: buildToolDescription(endpoint.toUpperCase(), operations),
+      name: TOOL_NAME_BY_ENDPOINT[endpoint.toUpperCase() as EndpointName],
+      description: buildToolDescription(endpoint.toUpperCase() as EndpointName, operations ?? []),
       inputSchema: {
         type: "object",
         properties: {
@@ -325,37 +357,35 @@ server.setRequestHandler(ListToolsRequestSchema as any, async () => ({
     })),
 }));
 
-server.setRequestHandler(CallToolRequestSchema as any, async (request: any) => {
+server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest): Promise<CallToolResult> => {
   const toolName = request.params.name;
-  const args = request.params.arguments ?? {};
-  const operation = args.operation;
+  const args = (request.params.arguments ?? {}) as OperationArguments;
+  const operation = typeof args.operation === "string" ? args.operation : "";
   const params = resolveParams(args);
 
   if (operation === "introspect") {
     const result = buildIntrospection(params);
-    return {
-      content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-    };
+    return textResult(result);
   }
 
   const item = TOOL_BY_OPERATION.get(operation);
   if (!item) {
-    return {
-      content: [{ type: "text", text: JSON.stringify({ success: false, error: { code: "NOT_FOUND_OPERATION", message: `Unknown operation: ${operation}` } }, null, 2) }],
-    };
+    return textResult({ success: false, error: { code: "NOT_FOUND_OPERATION", message: `Unknown operation: ${operation}` } });
   }
 
   const expectedToolName = TOOL_NAME_BY_ENDPOINT[item.endpoint];
   if (toolName !== expectedToolName) {
-    return {
-      content: [{ type: "text", text: JSON.stringify({ success: false, error: { code: "VALIDATION_WRONG_ENDPOINT", message: `Operation '${operation}' must be called via ${expectedToolName}.` } }, null, 2) }],
-    };
+    return textResult({
+      success: false,
+      error: {
+        code: "VALIDATION_WRONG_ENDPOINT",
+        message: `Operation '${operation}' must be called via ${expectedToolName}.`,
+      },
+    });
   }
 
   const result = await proxyOperation(operation, params);
-  return {
-    content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-  };
+  return textResult(result);
 });
 
 const transport = new StdioServerTransport();

--- a/generated/github-mcp/adapter/src/server.ts
+++ b/generated/github-mcp/adapter/src/server.ts
@@ -56,11 +56,15 @@ function textResult(payload: unknown): CallToolResult {
 
 function resolveToken(): string {
   const configured = schema.auth?.token_env;
+  if (!schema.auth || schema.auth.type !== "bearer") {
+    throw new Error("This adapter is not configured for bearer auth.");
+  }
+
   if (configured && process.env[configured]) {
     return process.env[configured];
   }
 
-  throw new Error(`Missing upstream bearer token in env var '${configured ?? "GITHUB_PERSONAL_ACCESS_TOKEN"}'.`);
+  throw new Error(`Missing upstream bearer token in env var '${configured ?? "UPSTREAM_BEARER_TOKEN"}'.`);
 }
 
 async function getUpstreamClient(): Promise<Client> {
@@ -70,9 +74,12 @@ async function getUpstreamClient(): Promise<Client> {
 
   const transport = new StreamableHTTPClientTransport(new URL(schema.target.base_url), {
     requestInit: {
-      headers: {
-        Authorization: `${schema.auth?.prefix ?? "Bearer "}${resolveToken()}`,
-      },
+      headers:
+        schema.auth?.type === "bearer"
+          ? {
+              Authorization: `${schema.auth.prefix ?? "Bearer "}${resolveToken()}`,
+            }
+          : undefined,
     },
   });
   const client = new Client({ name: schema.name, version: schema.version });
@@ -91,6 +98,7 @@ function resolveParams(args: OperationArguments | undefined): Record<string, unk
     return {};
   }
 
+  // Flat argument fallback exists for convenience, but it reserves the top-level operation/params keys.
   const clone = { ...args };
   delete clone.operation;
   return clone;
@@ -177,6 +185,7 @@ function buildOperationDetails(name: string) {
       minimum: param.minimum,
       maximum: param.maximum,
       pattern: param.pattern,
+      format: param.format,
     })),
     returns: {
       name: "WrappedToolResult",
@@ -351,6 +360,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (): Promise<ListToolsResu
         required: ["operation"],
       },
       annotations: {
+        // schema.operations keys are lowercase here because they come directly from the JSON schema document.
         readOnlyHint: endpoint === "read",
         destructiveHint: endpoint === "delete" || endpoint === "execute",
       },
@@ -391,8 +401,20 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
 const transport = new StdioServerTransport();
 await server.connect(transport);
 
-process.on("beforeExit", async () => {
+async function closeUpstreamTransport() {
   if (upstreamTransport) {
     await upstreamTransport.close();
+    upstreamTransport = undefined;
+    upstreamClient = undefined;
   }
+}
+
+process.on("beforeExit", async () => {
+  await closeUpstreamTransport();
 });
+
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.on(signal, () => {
+    void closeUpstreamTransport().finally(() => process.exit(0));
+  });
+}

--- a/generated/github-mcp/adapter/src/server.ts
+++ b/generated/github-mcp/adapter/src/server.ts
@@ -1,0 +1,368 @@
+// @ts-nocheck
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import schema from "./schema.json" with { type: "json" };
+import provenance from "./provenance.json" with { type: "json" };
+
+const TOOL_BY_OPERATION = new Map(
+  Object.entries(schema.operations)
+    .flatMap(([endpoint, operations]) => (operations ?? []).map((operation) => [operation.name, { endpoint: endpoint.toUpperCase(), definition: operation }]))
+);
+
+const TOOL_NAME_BY_ENDPOINT = {
+  CREATE: "mcp_aql_create",
+  READ: "mcp_aql_read",
+  UPDATE: "mcp_aql_update",
+  DELETE: "mcp_aql_delete",
+  EXECUTE: "mcp_aql_execute",
+};
+
+/** @type {Client | undefined} */
+let upstreamClient;
+/** @type {StreamableHTTPClientTransport | undefined} */
+let upstreamTransport;
+
+function resolveToken() {
+  const configured = schema.auth?.token_env;
+  if (configured && process.env[configured]) {
+    return process.env[configured];
+  }
+
+  throw new Error(`Missing upstream bearer token in env var '${configured ?? "GITHUB_PERSONAL_ACCESS_TOKEN"}'.`);
+}
+
+async function getUpstreamClient() {
+  if (upstreamClient) {
+    return upstreamClient;
+  }
+
+  const transport = new StreamableHTTPClientTransport(new URL(schema.target.base_url), {
+    requestInit: {
+      headers: {
+        Authorization: `${schema.auth?.prefix ?? "Bearer "}${resolveToken()}`,
+      },
+    },
+  });
+  const client = new Client({ name: schema.name, version: schema.version });
+  await client.connect(transport);
+  upstreamClient = client;
+  upstreamTransport = transport;
+  return upstreamClient;
+}
+
+function resolveParams(args) {
+  if (args && typeof args.params === "object" && args.params !== null) {
+    return args.params;
+  }
+
+  if (!args || typeof args !== "object") {
+    return {};
+  }
+
+  const clone = { ...args };
+  delete clone.operation;
+  return clone;
+}
+
+function buildToolDescription(endpoint, operations) {
+  const names = operations.map((operation) => operation.name).join(", ");
+  const quickStart = endpoint === "READ"
+    ? '{ operation: "introspect", params: { query: "operations" } }'
+    : `{ operation: "introspect", params: { query: "operations", name: "${operations[0]?.name ?? "introspect"}" } }`;
+
+  return [
+    `${endpoint} operations for ${schema.description}`,
+    "",
+    `Supported operations: ${names}`,
+    "",
+    "Discover required parameters:",
+    quickStart,
+  ].join("\n");
+}
+
+function buildIntrospectionOperations() {
+  const operations = [
+    {
+      name: "introspect",
+      endpoint: "READ",
+      description: "Discover available operations and wrapped upstream result types.",
+    },
+  ];
+
+  for (const [endpoint, entries] of Object.entries(schema.operations)) {
+    for (const operation of entries ?? []) {
+      operations.push({
+        name: operation.name,
+        endpoint: endpoint.toUpperCase(),
+        description: operation.description,
+      });
+    }
+  }
+
+  return operations;
+}
+
+function buildOperationDetails(name) {
+  if (name === "introspect") {
+    return {
+      name: "introspect",
+      endpoint: "READ",
+      mcpTool: "mcp_aql_read",
+      description: "Discover available operations and wrapped upstream result types.",
+      permissions: { readOnly: true, destructive: false },
+      parameters: [
+        { name: "query", type: "string", required: true, description: "Either 'operations' or 'types'.", enum: ["operations", "types"] },
+        { name: "name", type: "string", required: false, description: "Optional operation or type name for details." },
+      ],
+      returns: { name: "IntrospectionResult", kind: "object", description: "MCP-AQL introspection response payload." },
+      examples: [
+        { request: { operation: "introspect", params: { query: "operations" } } },
+      ],
+    };
+  }
+
+  const item = TOOL_BY_OPERATION.get(name);
+  if (!item) {
+    return null;
+  }
+
+  return {
+    name,
+    endpoint: item.endpoint,
+    mcpTool: TOOL_NAME_BY_ENDPOINT[item.endpoint],
+    description: item.definition.description,
+    permissions: {
+      readOnly: item.endpoint === "READ",
+      destructive: item.endpoint === "DELETE" || item.endpoint === "EXECUTE",
+    },
+    parameters: Object.entries(item.definition.params ?? {}).map(([paramName, param]) => ({
+      name: paramName,
+      type: param.type,
+      required: Boolean(param.required),
+      description: param.description,
+      default: param.default,
+      enum: param.enum,
+      minimum: param.minimum,
+      maximum: param.maximum,
+      pattern: param.pattern,
+    })),
+    returns: {
+      name: "WrappedToolResult",
+      kind: "object",
+      description: item.definition.response?.description ?? "Wrapped upstream MCP tool result.",
+    },
+    examples: [
+      {
+        request: {
+          operation: name,
+          params: Object.fromEntries(
+            Object.entries(item.definition.params ?? {}).map(([paramName, param]) => [
+              paramName,
+              param.default ?? (param.type === "integer" ? 1 : param.type === "boolean" ? true : `<${paramName}>`),
+            ]),
+          ),
+        },
+      },
+    ],
+  };
+}
+
+function buildTypeList() {
+  return [
+    {
+      name: "WrappedToolResult",
+      kind: "object",
+      description: "Standard wrapped result returned by generated MCP-AQL proxy operations.",
+    },
+  ];
+}
+
+function buildTypeDetails(name) {
+  if (name !== "WrappedToolResult") {
+    return null;
+  }
+
+  return {
+    name: "WrappedToolResult",
+    kind: "object",
+    description: "Wrapped upstream MCP tool result preserving content blocks and structured payloads.",
+    fields: [
+      { name: "source_tool", type: "string", required: true, description: "Original upstream MCP tool name." },
+      { name: "content", type: "array", required: true, description: "Raw MCP content blocks returned by the upstream tool." },
+      { name: "structured_content", type: "object", required: false, description: "Structured content returned by the upstream tool when available." },
+      { name: "is_error", type: "boolean", required: true, description: "Whether the upstream tool reported an MCP-level tool error." },
+    ],
+  };
+}
+
+function buildIntrospection(params) {
+  if (params.query === "operations") {
+    if (params.name) {
+      const operation = buildOperationDetails(params.name);
+      if (!operation) {
+        return { success: false, error: { code: "NOT_FOUND_OPERATION", message: `Unknown operation: ${params.name}` } };
+      }
+
+    return {
+      success: true,
+      data: { operation },
+    };
+    }
+
+    return {
+      success: true,
+      data: {
+        _protocol: {
+          version: schema.version,
+          mode: "crude",
+        },
+        operations: buildIntrospectionOperations(),
+      },
+    };
+  }
+
+  if (params.query === "types") {
+    if (params.name) {
+      const type = buildTypeDetails(params.name);
+      if (!type) {
+        return { success: false, error: { code: "NOT_FOUND_TYPE", message: `Unknown type: ${params.name}` } };
+      }
+
+      return {
+        success: true,
+        data: { type },
+      };
+    }
+
+    return {
+      success: true,
+      data: { types: buildTypeList() },
+    };
+  }
+
+  return {
+    success: false,
+    error: {
+      code: "VALIDATION_INVALID_QUERY",
+      message: `Unknown introspection query: ${params.query}`,
+    },
+  };
+}
+
+async function proxyOperation(operationName, params) {
+  const item = TOOL_BY_OPERATION.get(operationName);
+  if (!item) {
+    return {
+      success: false,
+      error: {
+        code: "NOT_FOUND_OPERATION",
+        message: `Unknown operation: ${operationName}`,
+      },
+    };
+  }
+
+  const upstream = await getUpstreamClient();
+  const sourceTool = item.definition.maps_to.replace(/^tool:/, "");
+  const result = await upstream.callTool({
+    name: sourceTool,
+    arguments: params,
+  });
+
+  if (result.isError) {
+    return {
+      success: false,
+      error: {
+        code: "UPSTREAM_TOOL_ERROR",
+        message: `Upstream MCP tool '${sourceTool}' returned an error.`,
+        details: {
+          source_tool: sourceTool,
+          content: result.content,
+          structured_content: result.structuredContent ?? null,
+        },
+      },
+      _meta: { provenance },
+    };
+  }
+
+  return {
+    success: true,
+    data: {
+      source_tool: sourceTool,
+      content: result.content,
+      structured_content: result.structuredContent ?? null,
+      is_error: Boolean(result.isError),
+    },
+    _meta: { provenance },
+  };
+}
+
+const server = new Server(
+  { name: schema.name, version: schema.version },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema as any, async () => ({
+  tools: Object.entries(schema.operations)
+    .filter(([, operations]) => Array.isArray(operations) && operations.length > 0)
+    .map(([endpoint, operations]) => ({
+      name: TOOL_NAME_BY_ENDPOINT[endpoint.toUpperCase()],
+      description: buildToolDescription(endpoint.toUpperCase(), operations),
+      inputSchema: {
+        type: "object",
+        properties: {
+          operation: { type: "string", description: "MCP-AQL operation name." },
+          params: { type: "object", description: "Operation parameters." },
+        },
+        required: ["operation"],
+      },
+      annotations: {
+        readOnlyHint: endpoint === "read",
+        destructiveHint: endpoint === "delete" || endpoint === "execute",
+      },
+    })),
+}));
+
+server.setRequestHandler(CallToolRequestSchema as any, async (request: any) => {
+  const toolName = request.params.name;
+  const args = request.params.arguments ?? {};
+  const operation = args.operation;
+  const params = resolveParams(args);
+
+  if (operation === "introspect") {
+    const result = buildIntrospection(params);
+    return {
+      content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+    };
+  }
+
+  const item = TOOL_BY_OPERATION.get(operation);
+  if (!item) {
+    return {
+      content: [{ type: "text", text: JSON.stringify({ success: false, error: { code: "NOT_FOUND_OPERATION", message: `Unknown operation: ${operation}` } }, null, 2) }],
+    };
+  }
+
+  const expectedToolName = TOOL_NAME_BY_ENDPOINT[item.endpoint];
+  if (toolName !== expectedToolName) {
+    return {
+      content: [{ type: "text", text: JSON.stringify({ success: false, error: { code: "VALIDATION_WRONG_ENDPOINT", message: `Operation '${operation}' must be called via ${expectedToolName}.` } }, null, 2) }],
+    };
+  }
+
+  const result = await proxyOperation(operation, params);
+  return {
+    content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+  };
+});
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+
+process.on("beforeExit", async () => {
+  if (upstreamTransport) {
+    await upstreamTransport.close();
+  }
+});

--- a/generated/github-mcp/adapter/tsconfig.json
+++ b/generated/github-mcp/adapter/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "strict": false,
+    "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,

--- a/generated/github-mcp/adapter/tsconfig.json
+++ b/generated/github-mcp/adapter/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/generated/github-mcp/capture/capture-metadata.json
+++ b/generated/github-mcp/capture/capture-metadata.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "1.0",
+  "source": {
+    "name": "github-mcp-remote",
+    "server_url": "https://api.githubcopilot.com/mcp/",
+    "transport": "streamable_http",
+    "captured_at": "2026-03-13T18:59:59.456Z",
+    "server": {
+      "name": "github-mcp-server",
+      "version": "github-mcp-server/remote-9f836f5fe414b6a085717f480c7f23093404340d",
+      "title": "GitHub MCP Server"
+    },
+    "auth": {
+      "type": "bearer",
+      "header": "Authorization",
+      "prefix": "Bearer ",
+      "token_command": "gh auth token"
+    },
+    "capture_config_redacted": {
+      "name": "github-mcp-remote",
+      "server_url": "https://api.githubcopilot.com/mcp/",
+      "transport": {
+        "type": "streamable_http"
+      },
+      "auth": {
+        "type": "bearer",
+        "token_command": "<redacted>",
+        "header": "Authorization",
+        "prefix": "Bearer "
+      }
+    }
+  },
+  "tool_count": 43,
+  "warning_count": 37
+}

--- a/generated/github-mcp/capture/capture-metadata.json
+++ b/generated/github-mcp/capture/capture-metadata.json
@@ -4,10 +4,10 @@
     "name": "github-mcp-remote",
     "server_url": "https://api.githubcopilot.com/mcp/",
     "transport": "streamable_http",
-    "captured_at": "2026-03-13T20:08:48.081Z",
+    "captured_at": "2026-03-19T04:08:21.992Z",
     "server": {
       "name": "github-mcp-server",
-      "version": "github-mcp-server/remote-9f836f5fe414b6a085717f480c7f23093404340d",
+      "version": "github-mcp-server/remote-212864f3b76a000b57f4f4f0435df686fc2bbc66",
       "title": "GitHub MCP Server"
     },
     "auth": {
@@ -30,6 +30,6 @@
       }
     }
   },
-  "tool_count": 43,
-  "warning_count": 37
+  "tool_count": 44,
+  "warning_count": 39
 }

--- a/generated/github-mcp/capture/capture-metadata.json
+++ b/generated/github-mcp/capture/capture-metadata.json
@@ -1,10 +1,10 @@
 {
-  "schema_version": "1.0",
+  "schema_version": "1.0.0-draft",
   "source": {
     "name": "github-mcp-remote",
     "server_url": "https://api.githubcopilot.com/mcp/",
     "transport": "streamable_http",
-    "captured_at": "2026-03-13T18:59:59.456Z",
+    "captured_at": "2026-03-13T20:08:48.081Z",
     "server": {
       "name": "github-mcp-server",
       "version": "github-mcp-server/remote-9f836f5fe414b6a085717f480c7f23093404340d",

--- a/generated/github-mcp/capture/discovery-bundle.json
+++ b/generated/github-mcp/capture/discovery-bundle.json
@@ -4,10 +4,10 @@
     "name": "github-mcp-remote",
     "server_url": "https://api.githubcopilot.com/mcp/",
     "transport": "streamable_http",
-    "captured_at": "2026-03-13T20:08:48.081Z",
+    "captured_at": "2026-03-19T04:08:21.992Z",
     "server": {
       "name": "github-mcp-server",
-      "version": "github-mcp-server/remote-9f836f5fe414b6a085717f480c7f23093404340d",
+      "version": "github-mcp-server/remote-212864f3b76a000b57f4f4f0435df686fc2bbc66",
       "title": "GitHub MCP Server"
     },
     "auth": {
@@ -1891,6 +1891,54 @@
         }
       },
       {
+        "name": "run_secret_scanning",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAC20lEQVRIidWUS4wMURSGv3O7kWmPEMRrSMzcbl1dpqtmGuOxsCKECCKxEBusSJhIWEhsWLFAbC1sWFiISBARCyQ2kzSZGaMxHokgXvGIiMH0PRZjpJqqHpb+TeX+59z//H/q5sD/DqlX9H1/zFeX2qzIKoFWYDKgwBtUymL0UkNaT3V3d3/+5wG2EGxB9TDIxGFMvhVhb9/drpN/NaDJC7MGdwJk6TDCv0Gvq0lve9R762GUNdFDLleaZNBrICGq+4yhvf9TJtP/KZNB2PrLlbBliBfRhajuAwnFVa/n8/nkxFkv3GO9oJrzgwVxdesV71ov6I2r5fxggfWCatYL9yYmUJgLPH7Q29WZ4OED6Me4wuAdeQK6MMqna9t0GuibBHFAmgZ9JMG9BhkXZWoSCDSATIq7aguBD0wBplq/tZBgYDIwKnZAs99mFRYD9vd/YK0dpcqhobM6d9haWyOULRTbAauwuNlvsxHTYP3iBnVyXGAa8BIYC3oVeAKioCtAPEE7FCOgR0ErIJdBBZgNskzh40+NF6K6s+9e91lp9osrxMnFoTSmSmPVsF+E5cB0YEDgtoMjjypd5wCy+WC9GnajhEAa4bkqV9LOHKwa9/yneYeyUqwX3AdyQ5EeVrrqro/hYL0g+ggemKh4HGbPmVu0+fB8U76lpR6XgJwZpoGUpNYiusZg1tXjkmCAav0OMTXfJC4eVYPqwbot6l4BCPqyLhd7lwMAWC/cYb3gi/UCzRaKOxsbFzVEM1iv2Ebt5v2Dm14qZbJecZf1Ah3UCrcTbbB+awHnjgHLgHeinHYqZ8aPSXWWy+XvcQZLpdKI9/0D7UbZiLIJmABckVSqo+/OrUrNgF+D8q1LEdcBrAJGAJ8ROlGeicorABWdAswE5gOjge8CF8Ad66v03IjqJb75WS0tE0YOmNWqLBGReaAzgIkMLrt3oM9UpSzCzW9pd+FpT8/7JK3/Gz8Ao5X6wtwP7N4AAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACCElEQVRIid2UPWsUYRSFn3dxWWJUkESiBgslFokfhehGiGClBBQx4h9IGlEh2ijYxh+gxEL/hIWwhYpF8KNZsFRJYdJEiUbjCkqisj4W+y6Mk5nd1U4PDMOce+45L3fmDvzXUDeo59WK+kb9rn5TF9R76jm1+2/NJ9QPtseSOv4nxrvVmQ6M05hRB9qZ98ZR1NRralntitdEwmw8wQ9HbS329rQKuKLW1XJO/aX6IqdWjr1Xk/y6lG4vMBdCqOacoZZ3uBBCVZ0HDrcK2AYs5ZkAuwBb1N8Dm5JEISXoAnqzOtU9QB+wVR3KCdgClDIr6kCc4c/0O1BLNnahiYpaSmmGY62e/JpCLJ4FpmmMaBHYCDwC5mmMZBQYBC7HnhvAK+B+fN4JHAM+R4+3wGQI4S7qaExtol+9o86pq+oX9Yk6ljjtGfVprK2qr9Xb6vaET109jjqb3Jac2XaM1PLNpok1Aep+G/+dfa24nADTX1EWTgOngLE2XCYKQL0DTfKex2WhXgCutxG9i/fFNlwWpgBQL6orcWyTaldToRbUA2pow61XL0WPFfXCb1HqkPowCj6q0+qIWsw7nlpUj6i31OXY+0AdbGpCRtNRGgt1AigCX4EqsJAYTR+wAzgEdAM/gApwM4TwOOm3JiARtBk4CYwAB4F+oIfGZi/HwOfAM6ASQviU5/Vv4xcBzmW2eT1nrQAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Scan files, content, or recent changes for secrets such as API keys, passwords, tokens, and credentials.\n\nThis tool is intended for targeted scans of specific files, snippets, or diffs provided directly as content. It accepts file contents or diffs and returns detected secrets with their locations and related secret scanning metadata. Content must not be empty. For full repository scanning, other mechanisms are available.\n\nCaveats:\n\n- Only files within the codebase should be scanned. Files outside of the codebase should not be sent.\n- Files listed in .gitignore should be skipped.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "files": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Array of file contents, snippets, or diff hunks to scan for secrets. These must be raw contents, not repository file paths.",
+              "minItems": 1,
+              "maxItems": 100
+            },
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            }
+          },
+          "required": [
+            "files",
+            "owner",
+            "repo"
+          ]
+        },
+        "annotations": {
+          "title": "Run Secret Scanning",
+          "readOnlyHint": true,
+          "openWorldHint": false
+        }
+      },
+      {
         "name": "search_code",
         "icons": [
           {
@@ -2407,6 +2455,14 @@
           "title": "Update pull request branch"
         }
       }
+    ],
+    "list_tools_page_count": 1,
+    "list_tools_pages": [
+      {
+        "cursor": null,
+        "next_cursor": null,
+        "tool_count": 44
+      }
     ]
   },
   "normalized_bundle": {
@@ -2682,11 +2738,13 @@
         "operation_name": "assign_copilot_to_issue",
         "title": "Assign Copilot to issue",
         "description": "Assign Copilot to a specific issue in a GitHub repository.\n\nThis tool can help with the following outcomes:\n- a Pull Request created with source code changes to resolve the issue\n\n\nMore information can be found at:\n- https://docs.github.com/en/copilot/using-github-copilot/using-copilot-coding-agent-to-work-on-tasks/about-assigning-tasks-to-copilot\n",
-        "endpoint": "CREATE",
-        "endpoint_confidence": "high",
+        "endpoint": "UPDATE",
+        "endpoint_confidence": "medium",
         "danger_level": "reversible",
-        "needs_review": false,
-        "review_reasons": [],
+        "needs_review": true,
+        "review_reasons": [
+          "Assignment semantics treated as UPDATE on an existing resource."
+        ],
         "params": [
           {
             "name": "base_ref",
@@ -4890,12 +4948,12 @@
         "operation_name": "pull_request_review_write",
         "title": "Write operations (create, submit, delete) on pull request reviews.",
         "description": "Create and/or submit, delete review of a pull request.\n\nAvailable methods:\n- create: Create a new review of a pull request. If \"event\" parameter is provided, the review is submitted. If \"event\" is omitted, a pending review is created.\n- submit_pending: Submit an existing pending review of a pull request. This requires that a pending review exists for the current user on the specified pull request. The \"body\" and \"event\" parameters are used when submitting the review.\n- delete_pending: Delete an existing pending review of a pull request. This requires that a pending review exists for the current user on the specified pull request.\n",
-        "endpoint": "UPDATE",
+        "endpoint": "DELETE",
         "endpoint_confidence": "medium",
-        "danger_level": "reversible",
+        "danger_level": "destructive",
         "needs_review": true,
         "review_reasons": [
-          "Write suffix is semantically broad and may hide create/update behavior."
+          "Description implies destructive behavior."
         ],
         "params": [
           {
@@ -5112,6 +5170,68 @@
           "description": "description",
           "annotations": [
             "title"
+          ],
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
+        }
+      },
+      {
+        "source_tool_name": "run_secret_scanning",
+        "operation_name": "run_secret_scanning",
+        "title": "Run Secret Scanning",
+        "description": "Scan files, content, or recent changes for secrets such as API keys, passwords, tokens, and credentials.\n\nThis tool is intended for targeted scans of specific files, snippets, or diffs provided directly as content. It accepts file contents or diffs and returns detected secrets with their locations and related secret scanning metadata. Content must not be empty. For full repository scanning, other mechanisms are available.\n\nCaveats:\n\n- Only files within the codebase should be scanned. Files outside of the codebase should not be sent.\n- Files listed in .gitignore should be skipped.",
+        "endpoint": "EXECUTE",
+        "endpoint_confidence": "medium",
+        "danger_level": "dangerous",
+        "needs_review": true,
+        "review_reasons": [
+          "Description implies workflow execution."
+        ],
+        "params": [
+          {
+            "name": "files",
+            "original_name": "files",
+            "type": "array",
+            "required": true,
+            "description": "Array of file contents, snippets, or diff hunks to scan for secrets. These must be raw contents, not repository file paths.",
+            "source_path": "inputSchema.properties.files"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          }
+        ],
+        "maps_to": "tool:run_secret_scanning",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "readOnlyHint",
+            "openWorldHint"
           ],
           "input_schema_present": true,
           "inference_sources": {
@@ -5947,6 +6067,13 @@
       },
       {
         "code": "REVIEW_REQUIRED",
+        "severity": "info",
+        "message": "Assignment semantics treated as UPDATE on an existing resource.",
+        "tool": "assign_copilot_to_issue",
+        "heuristic": "endpoint_classification"
+      },
+      {
+        "code": "REVIEW_REQUIRED",
         "severity": "warning",
         "message": "Tool name spans both create and update semantics.",
         "tool": "create_or_update_file",
@@ -6073,7 +6200,7 @@
       {
         "code": "REVIEW_REQUIRED",
         "severity": "info",
-        "message": "Write suffix is semantically broad and may hide create/update behavior.",
+        "message": "Description implies destructive behavior.",
         "tool": "pull_request_review_write",
         "heuristic": "endpoint_classification"
       },
@@ -6114,6 +6241,13 @@
         "tool": "request_copilot_review",
         "field": "pullNumber",
         "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "REVIEW_REQUIRED",
+        "severity": "info",
+        "message": "Description implies workflow execution.",
+        "tool": "run_secret_scanning",
+        "heuristic": "endpoint_classification"
       },
       {
         "code": "PARAM_NAME_NORMALIZED",

--- a/generated/github-mcp/capture/discovery-bundle.json
+++ b/generated/github-mcp/capture/discovery-bundle.json
@@ -1,0 +1,5890 @@
+{
+  "schema_version": "1.0",
+  "source": {
+    "name": "github-mcp-remote",
+    "server_url": "https://api.githubcopilot.com/mcp/",
+    "transport": "streamable_http",
+    "captured_at": "2026-03-13T18:59:59.456Z",
+    "server": {
+      "name": "github-mcp-server",
+      "version": "github-mcp-server/remote-9f836f5fe414b6a085717f480c7f23093404340d",
+      "title": "GitHub MCP Server"
+    },
+    "auth": {
+      "type": "bearer",
+      "header": "Authorization",
+      "prefix": "Bearer ",
+      "token_command": "gh auth token"
+    },
+    "capture_config_redacted": {
+      "name": "github-mcp-remote",
+      "server_url": "https://api.githubcopilot.com/mcp/",
+      "transport": {
+        "type": "streamable_http"
+      },
+      "auth": {
+        "type": "bearer",
+        "token_command": "<redacted>",
+        "header": "Authorization",
+        "prefix": "Bearer "
+      }
+    }
+  },
+  "raw_capture": {
+    "tools": [
+      {
+        "name": "add_comment_to_pending_review",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACwUlEQVRIie2Vz28UZRjHP993pi0QIC3YahNjirtmd3bS3Q1eUHvQEPUiEv8A4kXjwRJ78MCFBLjBBRKCHowHE38cNCbGGx6IUoKiodtNpoNmTJp4oSJNQ3pw29l5POxus2wo3QTwxPc0887zfD7zvu9kXnjEUfdNrjj5vJOmMP4e9JrfR1G02tuQD8tvgpck0dxCPwK30ViqnJTcr4bOmfRlI/PrhUJ5313woDpDpu8ss7f6nYHrvDnGcYlPsoY/bKaXwHY3HWfvgmNnMX0zvMM7069A3c3pkEYWa7UVgFxQPSfs7SSeH3k2rEy5jMubMBoG1yQ+SBbm53of+gCybMkk/H8VAFdbZisZLAFsJ11oyL+BUURcwrjWAZixXeIwxs/5UuVAr0QAYRjubGR+HWy3mb6QCIBXQe8nce0jgIkwfMo3/xLG085x8I9ofkMyUa0O+w2rgS0mcf3lboEDiKJo1cvsIDDr4D1DhTb8407hYhTdTJW+AvrdMnuhG9Je1m9BBzbfjXbyQcXypeqJLQt7+0rVE/mgYr3j7l7FDzOPBY8FDx6vc1EolPeNjI5/Jpgw7Lm9o+Pry//c/K0PhnLFyrSMDxE79jwxvn9079gvt28vrUD7V1EoFHalbltd2C7DfS4sAF4DTSdx7cL96LliZVriPPADuL+geRh0Z8il5SiKVn2ATENvCCYw78U/b8xdBcgHlYuGHQXuK5A4ClxM4vnXW8Lqp5JdWWt6h4CvWnsgxgDSbRZ3Gg0tCJ7sY4nGwDZOt/WBZtzN9FswLgM2sGann5mcPDaw5pWEHQH7cUu86SdkR3LF6tfrA814MNVpwNrM1leUxPXrSKfMeHcwdctyNotY8c3NbMX3LJsB3ZHsymDqlkHvYHYyievXWxPpSj4o75eYIuPWZof+vRKG4c61pncIx6gZsx34/5L/ACy3ElqUYhuvAAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABn0lEQVRIie2Vvy5EURDGvyMUkhUU/pS2Q2clwvIKqL0Cm9ArrBcQShJPoLFR2YaIhIjQ7a7E39IiCgqVn8KsPY697E3oTHPumTPf990z986M9Mfm/A0wKGlMUlnSlnPuOQQAE5LOnXOFWErAIvBK1S6BZBAzZ2fzcckHjXwVaAXSwD2wWYN8A2iKK1ABt3m+ZeDRnseIthdgDxioxd1o662tfZIO7Lnf8xcklST1StqRdORxNEualHQIDDvnTmvdIGE5vwdWgLy93bQX0w0UgSdgKMC3AdfA7ndpSgKbduUbYBoI/7Ju4BiYrYFfAl4iBbxAgOyPgV9xWYDQ3xCXKK79C/wL/KJZoeW8QpsJCy0C54AMULaGmQu7sIAW4MpaxTKwbQU3U4dAxmLzwLpxXAIJP2jKgkY8Xx4o1SFwBmx7+7RxTUnVb9Bpa9HDFiR1/SRgWH+6FT3/h2qK6sBpB0aBB7yB880NcpaWtGHXjCsVBmb5PDIvgJ46BJKW84q9AguV87Adp/Q+9O8UMfQjRBKSxiV1SNp3zp3Ug/sVewPruexhKwhGXQAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Add review comment to the requester's latest pending pull request review. A pending review needs to already exist to call this (check with the user if not sure).",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "body": {
+              "type": "string",
+              "description": "The text of the review comment"
+            },
+            "line": {
+              "type": "number",
+              "description": "The line of the blob in the pull request diff that the comment applies to. For multi-line comments, the last line of the range"
+            },
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "path": {
+              "type": "string",
+              "description": "The relative path to the file that necessitates a comment"
+            },
+            "pullNumber": {
+              "type": "number",
+              "description": "Pull request number"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            },
+            "side": {
+              "type": "string",
+              "description": "The side of the diff to comment on. LEFT indicates the previous state, RIGHT indicates the new state",
+              "enum": [
+                "LEFT",
+                "RIGHT"
+              ]
+            },
+            "startLine": {
+              "type": "number",
+              "description": "For multi-line comments, the first line of the range that the comment applies to"
+            },
+            "startSide": {
+              "type": "string",
+              "description": "For multi-line comments, the starting side of the diff that the comment applies to. LEFT indicates the previous state, RIGHT indicates the new state",
+              "enum": [
+                "LEFT",
+                "RIGHT"
+              ]
+            },
+            "subjectType": {
+              "type": "string",
+              "description": "The level at which the comment is targeted",
+              "enum": [
+                "FILE",
+                "LINE"
+              ]
+            }
+          },
+          "required": [
+            "owner",
+            "repo",
+            "pullNumber",
+            "path",
+            "body",
+            "subjectType"
+          ]
+        },
+        "annotations": {
+          "title": "Add review comment to the requester's latest pending pull request review"
+        }
+      },
+      {
+        "name": "add_issue_comment",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAC2UlEQVRIicWVMUyTaRjHf/+vVUpOJOdilOYoUvVreq2CDmLOwdlAS5xMbrrhBifjYG7QjYuJw108nZx1huLgYlw0QshxChUK2koxHHcuCmgsFfieG0or3kGPSoz/8X3f5/97nvfN8z7wmaVqm9FodFfR/EnMugy5giCAwYwgI9Ff9Hl9L9Lp1zUBgsGO+rqGwnlhF4CdwBSyAUwvS1G220zHBSFgHtmVxYWvfp2ZGSj8LyAcjgfZphTQZtAr7OdsZvSP9RIJR+LtQhcNusF+d1aUfPp05M8NAavmg8AOk3cmN56+s1Hpa7U/cviUYbcw3jgex9ZCKoBgsKM+0PDuAdBq2He5zOiTzZiXtc+NxRw598GeLRcWTuTz+UUAp3ygrqFwHmgzeWdqNQd4PpFOy/gedNQfaDz3UQXRaHRX0fNPGdzNZUZO12q+VuHIoV7g5Hu/1/IinX7tABTNnwR2SvRsxRzAzOsBGuuWfAkoX5FZFzCVHR95tFVAbiI9DEwj6wLwl5YVMTRYLTDsxjuRrgGYYz/kxkbvbXRWMOBB24cKYI9ks1X8hXQDaAaa5XG9WjImZgV71wI+m8qAv8y0t1pSmP0ITANTmHO2qqvRZDALlTdgHKyjWkx2YvQ2cHtTacMxYBhWK5DoF4TCkXj7Jg02VKsbOwI0Y+qvALZrOQXMC13cKkDSJWBuJUCqAhgbG3uF7IpBcn/k8KlPNQ+78U5QQuhy/vHjuQoAYPndwi9gw4bd2ufGYrWatxz8No50ExhaKsz9Vl6vAPL5/KKzoiTGG0fOg1oqCbvxTp/juw/M+zynu/yTwjoD58CBQ02ez/pAR4E+M69ntf3/o1Y3dqR050oAQz7P6Z6cfPRRw647MkOhUMAfaDyH+AloBKYNPRT292rQHoMOSp09J3TZlt5ezWazxX97VR3638RiX9ct+RImSyBcrDT0ETMyMp4ptRIgVX7QL6J/ALSUEwJ5rdg2AAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABxElEQVRIibWVvW4TURCFv0vlNEDcIHAkKAERJOIKSjoUArwBPwUFFaKIIngAJARCPIgdh4cgRBYt6ZIAEYEqdhpEw0fhCbkKa68dxyNtsfNzzpnZu3NhwpYGBdUqcA+4A1wEZiK0DawD74FWSml3JAJ1CngGLAIngU1gFfgZKWeAG8AFoAu8At6mlH6VtqTOqJ/UP2pDnRuQO6c27VlbrQ0Dvq121Fulag7q5qPmW18SdSqUd9Qrw4Jn9bNR21YrRQkvYixDKy/AuB3jWjocqKpdtXFU8AxrOTqZzp2PgvnaMRDUA+tB7mypG+OCZ3hbahPgRPguAR9LihaicEu9WcKxClzOi/fU1wPAk7rjgX0uEfNG3cs7mJjtE+wA5/olpZQEHgNf6K2NJyW4NeD7v7c4WptjSc0svlMjdzyM2fbdOyOA7x/T+7mzGj9H8xgIWuquevpw4HmsivkxwBdC/WJRsBKLqqPOHgH8aqybtcJlF0m1WLndUToJ5V31q9r3NOYk7Wh1Wa0PyK3HzA3l/4H3uzIrwFNgCThF7/x/AH5EylngOnAe6AAvgXcppd9DEWRE08DdeIou/RVgJaXUGYQzUfsL+zmwV7BtIq0AAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Add a comment to a specific issue in a GitHub repository. Use this tool to add comments to pull requests as well (in this case pass pull request number as issue_number), but only if user is not asking specifically to add review comments.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "body": {
+              "type": "string",
+              "description": "Comment content"
+            },
+            "issue_number": {
+              "type": "number",
+              "description": "Issue number to comment on"
+            },
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            }
+          },
+          "required": [
+            "owner",
+            "repo",
+            "issue_number",
+            "body"
+          ]
+        },
+        "annotations": {
+          "title": "Add comment to issue"
+        }
+      },
+      {
+        "name": "add_reply_to_pull_request_comment",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACwUlEQVRIie2Vz28UZRjHP993pi0QIC3YahNjirtmd3bS3Q1eUHvQEPUiEv8A4kXjwRJ78MCFBLjBBRKCHowHE38cNCbGGx6IUoKiodtNpoNmTJp4oSJNQ3pw29l5POxus2wo3QTwxPc0887zfD7zvu9kXnjEUfdNrjj5vJOmMP4e9JrfR1G02tuQD8tvgpck0dxCPwK30ViqnJTcr4bOmfRlI/PrhUJ5313woDpDpu8ss7f6nYHrvDnGcYlPsoY/bKaXwHY3HWfvgmNnMX0zvMM7069A3c3pkEYWa7UVgFxQPSfs7SSeH3k2rEy5jMubMBoG1yQ+SBbm53of+gCybMkk/H8VAFdbZisZLAFsJ11oyL+BUURcwrjWAZixXeIwxs/5UuVAr0QAYRjubGR+HWy3mb6QCIBXQe8nce0jgIkwfMo3/xLG085x8I9ofkMyUa0O+w2rgS0mcf3lboEDiKJo1cvsIDDr4D1DhTb8407hYhTdTJW+AvrdMnuhG9Je1m9BBzbfjXbyQcXypeqJLQt7+0rVE/mgYr3j7l7FDzOPBY8FDx6vc1EolPeNjI5/Jpgw7Lm9o+Pry//c/K0PhnLFyrSMDxE79jwxvn9079gvt28vrUD7V1EoFHalbltd2C7DfS4sAF4DTSdx7cL96LliZVriPPADuL+geRh0Z8il5SiKVn2ATENvCCYw78U/b8xdBcgHlYuGHQXuK5A4ClxM4vnXW8Lqp5JdWWt6h4CvWnsgxgDSbRZ3Gg0tCJ7sY4nGwDZOt/WBZtzN9FswLgM2sGann5mcPDaw5pWEHQH7cUu86SdkR3LF6tfrA814MNVpwNrM1leUxPXrSKfMeHcwdctyNotY8c3NbMX3LJsB3ZHsymDqlkHvYHYyievXWxPpSj4o75eYIuPWZof+vRKG4c61pncIx6gZsx34/5L/ACy3ElqUYhuvAAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABn0lEQVRIie2Vvy5EURDGvyMUkhUU/pS2Q2clwvIKqL0Cm9ArrBcQShJPoLFR2YaIhIjQ7a7E39IiCgqVn8KsPY697E3oTHPumTPf990z986M9Mfm/A0wKGlMUlnSlnPuOQQAE5LOnXOFWErAIvBK1S6BZBAzZ2fzcckHjXwVaAXSwD2wWYN8A2iKK1ABt3m+ZeDRnseIthdgDxioxd1o662tfZIO7Lnf8xcklST1StqRdORxNEualHQIDDvnTmvdIGE5vwdWgLy93bQX0w0UgSdgKMC3AdfA7ndpSgKbduUbYBoI/7Ju4BiYrYFfAl4iBbxAgOyPgV9xWYDQ3xCXKK79C/wL/KJZoeW8QpsJCy0C54AMULaGmQu7sIAW4MpaxTKwbQU3U4dAxmLzwLpxXAIJP2jKgkY8Xx4o1SFwBmx7+7RxTUnVb9Bpa9HDFiR1/SRgWH+6FT3/h2qK6sBpB0aBB7yB880NcpaWtGHXjCsVBmb5PDIvgJ46BJKW84q9AguV87Adp/Q+9O8UMfQjRBKSxiV1SNp3zp3Ug/sVewPruexhKwhGXQAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Add a reply to an existing pull request comment. This creates a new comment that is linked as a reply to the specified comment.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "body": {
+              "type": "string",
+              "description": "The text of the reply"
+            },
+            "commentId": {
+              "type": "number",
+              "description": "The ID of the comment to reply to"
+            },
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "pullNumber": {
+              "type": "number",
+              "description": "Pull request number"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            }
+          },
+          "required": [
+            "owner",
+            "repo",
+            "pullNumber",
+            "commentId",
+            "body"
+          ]
+        },
+        "annotations": {
+          "title": "Add reply to pull request comment"
+        }
+      },
+      {
+        "name": "assign_copilot_to_issue",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAC20lEQVRIidWUS4wMURSGv3O7kWmPEMRrSMzcbl1dpqtmGuOxsCKECCKxEBusSJhIWEhsWLFAbC1sWFiISBARCyQ2kzSZGaMxHokgXvGIiMH0PRZjpJqqHpb+TeX+59z//H/q5sD/DqlX9H1/zFeX2qzIKoFWYDKgwBtUymL0UkNaT3V3d3/+5wG2EGxB9TDIxGFMvhVhb9/drpN/NaDJC7MGdwJk6TDCv0Gvq0lve9R762GUNdFDLleaZNBrICGq+4yhvf9TJtP/KZNB2PrLlbBliBfRhajuAwnFVa/n8/nkxFkv3GO9oJrzgwVxdesV71ov6I2r5fxggfWCatYL9yYmUJgLPH7Q29WZ4OED6Me4wuAdeQK6MMqna9t0GuibBHFAmgZ9JMG9BhkXZWoSCDSATIq7aguBD0wBplq/tZBgYDIwKnZAs99mFRYD9vd/YK0dpcqhobM6d9haWyOULRTbAauwuNlvsxHTYP3iBnVyXGAa8BIYC3oVeAKioCtAPEE7FCOgR0ErIJdBBZgNskzh40+NF6K6s+9e91lp9osrxMnFoTSmSmPVsF+E5cB0YEDgtoMjjypd5wCy+WC9GnajhEAa4bkqV9LOHKwa9/yneYeyUqwX3AdyQ5EeVrrqro/hYL0g+ggemKh4HGbPmVu0+fB8U76lpR6XgJwZpoGUpNYiusZg1tXjkmCAav0OMTXfJC4eVYPqwbot6l4BCPqyLhd7lwMAWC/cYb3gi/UCzRaKOxsbFzVEM1iv2Ebt5v2Dm14qZbJecZf1Ah3UCrcTbbB+awHnjgHLgHeinHYqZ8aPSXWWy+XvcQZLpdKI9/0D7UbZiLIJmABckVSqo+/OrUrNgF+D8q1LEdcBrAJGAJ8ROlGeicorABWdAswE5gOjge8CF8Ad66v03IjqJb75WS0tE0YOmNWqLBGReaAzgIkMLrt3oM9UpSzCzW9pd+FpT8/7JK3/Gz8Ao5X6wtwP7N4AAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACCElEQVRIid2UPWsUYRSFn3dxWWJUkESiBgslFokfhehGiGClBBQx4h9IGlEh2ijYxh+gxEL/hIWwhYpF8KNZsFRJYdJEiUbjCkqisj4W+y6Mk5nd1U4PDMOce+45L3fmDvzXUDeo59WK+kb9rn5TF9R76jm1+2/NJ9QPtseSOv4nxrvVmQ6M05hRB9qZ98ZR1NRralntitdEwmw8wQ9HbS329rQKuKLW1XJO/aX6IqdWjr1Xk/y6lG4vMBdCqOacoZZ3uBBCVZ0HDrcK2AYs5ZkAuwBb1N8Dm5JEISXoAnqzOtU9QB+wVR3KCdgClDIr6kCc4c/0O1BLNnahiYpaSmmGY62e/JpCLJ4FpmmMaBHYCDwC5mmMZBQYBC7HnhvAK+B+fN4JHAM+R4+3wGQI4S7qaExtol+9o86pq+oX9Yk6ljjtGfVprK2qr9Xb6vaET109jjqb3Jac2XaM1PLNpok1Aep+G/+dfa24nADTX1EWTgOngLE2XCYKQL0DTfKex2WhXgCutxG9i/fFNlwWpgBQL6orcWyTaldToRbUA2pow61XL0WPFfXCb1HqkPowCj6q0+qIWsw7nlpUj6i31OXY+0AdbGpCRtNRGgt1AigCX4EqsJAYTR+wAzgEdAM/gApwM4TwOOm3JiARtBk4CYwAB4F+oIfGZi/HwOfAM6ASQviU5/Vv4xcBzmW2eT1nrQAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Assign Copilot to a specific issue in a GitHub repository.\n\nThis tool can help with the following outcomes:\n- a Pull Request created with source code changes to resolve the issue\n\n\nMore information can be found at:\n- https://docs.github.com/en/copilot/using-github-copilot/using-copilot-coding-agent-to-work-on-tasks/about-assigning-tasks-to-copilot\n",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "base_ref": {
+              "type": "string",
+              "description": "Git reference (e.g., branch) that the agent will start its work from. If not specified, defaults to the repository's default branch"
+            },
+            "custom_instructions": {
+              "type": "string",
+              "description": "Optional custom instructions to guide the agent beyond the issue body. Use this to provide additional context, constraints, or guidance that is not captured in the issue description"
+            },
+            "issue_number": {
+              "type": "number",
+              "description": "Issue number"
+            },
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            }
+          },
+          "required": [
+            "owner",
+            "repo",
+            "issue_number"
+          ]
+        },
+        "annotations": {
+          "title": "Assign Copilot to issue",
+          "idempotentHint": true
+        }
+      },
+      {
+        "name": "create_branch",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Create a new branch in a GitHub repository",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "branch": {
+              "type": "string",
+              "description": "Name for new branch"
+            },
+            "from_branch": {
+              "type": "string",
+              "description": "Source branch (defaults to repo default)"
+            },
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            }
+          },
+          "required": [
+            "owner",
+            "repo",
+            "branch"
+          ]
+        },
+        "annotations": {
+          "title": "Create branch"
+        }
+      },
+      {
+        "name": "create_or_update_file",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Create or update a single file in a GitHub repository. \nIf updating, you should provide the SHA of the file you want to update. Use this tool to create or update a file in a GitHub repository remotely; do not use it for local file operations.\n\nIn order to obtain the SHA of original file version before updating, use the following git command:\ngit rev-parse <branch>:<path to file>\n\nSHA MUST be provided for existing file updates.\n",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "branch": {
+              "type": "string",
+              "description": "Branch to create/update the file in"
+            },
+            "content": {
+              "type": "string",
+              "description": "Content of the file"
+            },
+            "message": {
+              "type": "string",
+              "description": "Commit message"
+            },
+            "owner": {
+              "type": "string",
+              "description": "Repository owner (username or organization)"
+            },
+            "path": {
+              "type": "string",
+              "description": "Path where to create/update the file"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            },
+            "sha": {
+              "type": "string",
+              "description": "The blob SHA of the file being replaced. Required if the file already exists."
+            }
+          },
+          "required": [
+            "owner",
+            "repo",
+            "path",
+            "content",
+            "message",
+            "branch"
+          ]
+        },
+        "annotations": {
+          "title": "Create or update file"
+        }
+      },
+      {
+        "name": "create_pull_request",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACwUlEQVRIie2Vz28UZRjHP993pi0QIC3YahNjirtmd3bS3Q1eUHvQEPUiEv8A4kXjwRJ78MCFBLjBBRKCHowHE38cNCbGGx6IUoKiodtNpoNmTJp4oSJNQ3pw29l5POxus2wo3QTwxPc0887zfD7zvu9kXnjEUfdNrjj5vJOmMP4e9JrfR1G02tuQD8tvgpck0dxCPwK30ViqnJTcr4bOmfRlI/PrhUJ5313woDpDpu8ss7f6nYHrvDnGcYlPsoY/bKaXwHY3HWfvgmNnMX0zvMM7069A3c3pkEYWa7UVgFxQPSfs7SSeH3k2rEy5jMubMBoG1yQ+SBbm53of+gCybMkk/H8VAFdbZisZLAFsJ11oyL+BUURcwrjWAZixXeIwxs/5UuVAr0QAYRjubGR+HWy3mb6QCIBXQe8nce0jgIkwfMo3/xLG085x8I9ofkMyUa0O+w2rgS0mcf3lboEDiKJo1cvsIDDr4D1DhTb8407hYhTdTJW+AvrdMnuhG9Je1m9BBzbfjXbyQcXypeqJLQt7+0rVE/mgYr3j7l7FDzOPBY8FDx6vc1EolPeNjI5/Jpgw7Lm9o+Pry//c/K0PhnLFyrSMDxE79jwxvn9079gvt28vrUD7V1EoFHalbltd2C7DfS4sAF4DTSdx7cL96LliZVriPPADuL+geRh0Z8il5SiKVn2ATENvCCYw78U/b8xdBcgHlYuGHQXuK5A4ClxM4vnXW8Lqp5JdWWt6h4CvWnsgxgDSbRZ3Gg0tCJ7sY4nGwDZOt/WBZtzN9FswLgM2sGann5mcPDaw5pWEHQH7cUu86SdkR3LF6tfrA814MNVpwNrM1leUxPXrSKfMeHcwdctyNotY8c3NbMX3LJsB3ZHsymDqlkHvYHYyievXWxPpSj4o75eYIuPWZof+vRKG4c61pncIx6gZsx34/5L/ACy3ElqUYhuvAAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABn0lEQVRIie2Vvy5EURDGvyMUkhUU/pS2Q2clwvIKqL0Cm9ArrBcQShJPoLFR2YaIhIjQ7a7E39IiCgqVn8KsPY697E3oTHPumTPf990z986M9Mfm/A0wKGlMUlnSlnPuOQQAE5LOnXOFWErAIvBK1S6BZBAzZ2fzcckHjXwVaAXSwD2wWYN8A2iKK1ABt3m+ZeDRnseIthdgDxioxd1o662tfZIO7Lnf8xcklST1StqRdORxNEualHQIDDvnTmvdIGE5vwdWgLy93bQX0w0UgSdgKMC3AdfA7ndpSgKbduUbYBoI/7Ju4BiYrYFfAl4iBbxAgOyPgV9xWYDQ3xCXKK79C/wL/KJZoeW8QpsJCy0C54AMULaGmQu7sIAW4MpaxTKwbQU3U4dAxmLzwLpxXAIJP2jKgkY8Xx4o1SFwBmx7+7RxTUnVb9Bpa9HDFiR1/SRgWH+6FT3/h2qK6sBpB0aBB7yB880NcpaWtGHXjCsVBmb5PDIvgJ46BJKW84q9AguV87Adp/Q+9O8UMfQjRBKSxiV1SNp3zp3Ug/sVewPruexhKwhGXQAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Create a new pull request in a GitHub repository.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "base": {
+              "type": "string",
+              "description": "Branch to merge into"
+            },
+            "body": {
+              "type": "string",
+              "description": "PR description"
+            },
+            "draft": {
+              "type": "boolean",
+              "description": "Create as draft PR"
+            },
+            "head": {
+              "type": "string",
+              "description": "Branch containing changes"
+            },
+            "maintainer_can_modify": {
+              "type": "boolean",
+              "description": "Allow maintainer edits"
+            },
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            },
+            "title": {
+              "type": "string",
+              "description": "PR title"
+            }
+          },
+          "required": [
+            "owner",
+            "repo",
+            "title",
+            "head",
+            "base"
+          ]
+        },
+        "annotations": {
+          "title": "Open new pull request"
+        }
+      },
+      {
+        "name": "create_pull_request_with_copilot",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAC20lEQVRIidWUS4wMURSGv3O7kWmPEMRrSMzcbl1dpqtmGuOxsCKECCKxEBusSJhIWEhsWLFAbC1sWFiISBARCyQ2kzSZGaMxHokgXvGIiMH0PRZjpJqqHpb+TeX+59z//H/q5sD/DqlX9H1/zFeX2qzIKoFWYDKgwBtUymL0UkNaT3V3d3/+5wG2EGxB9TDIxGFMvhVhb9/drpN/NaDJC7MGdwJk6TDCv0Gvq0lve9R762GUNdFDLleaZNBrICGq+4yhvf9TJtP/KZNB2PrLlbBliBfRhajuAwnFVa/n8/nkxFkv3GO9oJrzgwVxdesV71ov6I2r5fxggfWCatYL9yYmUJgLPH7Q29WZ4OED6Me4wuAdeQK6MMqna9t0GuibBHFAmgZ9JMG9BhkXZWoSCDSATIq7aguBD0wBplq/tZBgYDIwKnZAs99mFRYD9vd/YK0dpcqhobM6d9haWyOULRTbAauwuNlvsxHTYP3iBnVyXGAa8BIYC3oVeAKioCtAPEE7FCOgR0ErIJdBBZgNskzh40+NF6K6s+9e91lp9osrxMnFoTSmSmPVsF+E5cB0YEDgtoMjjypd5wCy+WC9GnajhEAa4bkqV9LOHKwa9/yneYeyUqwX3AdyQ5EeVrrqro/hYL0g+ggemKh4HGbPmVu0+fB8U76lpR6XgJwZpoGUpNYiusZg1tXjkmCAav0OMTXfJC4eVYPqwbot6l4BCPqyLhd7lwMAWC/cYb3gi/UCzRaKOxsbFzVEM1iv2Ebt5v2Dm14qZbJecZf1Ah3UCrcTbbB+awHnjgHLgHeinHYqZ8aPSXWWy+XvcQZLpdKI9/0D7UbZiLIJmABckVSqo+/OrUrNgF+D8q1LEdcBrAJGAJ8ROlGeicorABWdAswE5gOjge8CF8Ad66v03IjqJb75WS0tE0YOmNWqLBGReaAzgIkMLrt3oM9UpSzCzW9pd+FpT8/7JK3/Gz8Ao5X6wtwP7N4AAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACCElEQVRIid2UPWsUYRSFn3dxWWJUkESiBgslFokfhehGiGClBBQx4h9IGlEh2ijYxh+gxEL/hIWwhYpF8KNZsFRJYdJEiUbjCkqisj4W+y6Mk5nd1U4PDMOce+45L3fmDvzXUDeo59WK+kb9rn5TF9R76jm1+2/NJ9QPtseSOv4nxrvVmQ6M05hRB9qZ98ZR1NRralntitdEwmw8wQ9HbS329rQKuKLW1XJO/aX6IqdWjr1Xk/y6lG4vMBdCqOacoZZ3uBBCVZ0HDrcK2AYs5ZkAuwBb1N8Dm5JEISXoAnqzOtU9QB+wVR3KCdgClDIr6kCc4c/0O1BLNnahiYpaSmmGY62e/JpCLJ4FpmmMaBHYCDwC5mmMZBQYBC7HnhvAK+B+fN4JHAM+R4+3wGQI4S7qaExtol+9o86pq+oX9Yk6ljjtGfVprK2qr9Xb6vaET109jjqb3Jac2XaM1PLNpok1Aep+G/+dfa24nADTX1EWTgOngLE2XCYKQL0DTfKex2WhXgCutxG9i/fFNlwWpgBQL6orcWyTaldToRbUA2pow61XL0WPFfXCb1HqkPowCj6q0+qIWsw7nlpUj6i31OXY+0AdbGpCRtNRGgt1AigCX4EqsJAYTR+wAzgEdAM/gApwM4TwOOm3JiARtBk4CYwAB4F+oIfGZi/HwOfAM6ASQviU5/Vv4xcBzmW2eT1nrQAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Delegate a task to GitHub Copilot coding agent to perform in the background. The agent will create a pull request with the implementation. You should use this tool if the user asks to create a pull request to perform a specific task, or if the user asks Copilot to do something.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "base_ref": {
+              "type": "string",
+              "description": "Git reference (e.g., branch) that the agent will start its work from. If not specified, defaults to the repository's default branch"
+            },
+            "owner": {
+              "type": "string",
+              "description": "Repository owner. You can guess the owner, but confirm it with the user before proceeding."
+            },
+            "problem_statement": {
+              "type": "string",
+              "description": "Detailed description of the task to be performed (e.g., 'Implement a feature that does X', 'Fix bug Y', etc.)"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name. You can guess the repository name, but confirm it with the user before proceeding."
+            },
+            "title": {
+              "type": "string",
+              "description": "Title for the pull request that will be created"
+            }
+          },
+          "required": [
+            "owner",
+            "repo",
+            "problem_statement",
+            "title"
+          ]
+        },
+        "annotations": {
+          "title": "Perform task with GitHub Copilot coding agent",
+          "openWorldHint": false
+        }
+      },
+      {
+        "name": "create_repository",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Create a new GitHub repository in your account or specified organization",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "autoInit": {
+              "type": "boolean",
+              "description": "Initialize with README"
+            },
+            "description": {
+              "type": "string",
+              "description": "Repository description"
+            },
+            "name": {
+              "type": "string",
+              "description": "Repository name"
+            },
+            "organization": {
+              "type": "string",
+              "description": "Organization to create the repository in (omit to create in your personal account)"
+            },
+            "private": {
+              "type": "boolean",
+              "description": "Whether repo should be private"
+            }
+          },
+          "required": [
+            "name"
+          ]
+        },
+        "annotations": {
+          "title": "Create repository"
+        }
+      },
+      {
+        "name": "delete_file",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Delete a file from a GitHub repository",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "branch": {
+              "type": "string",
+              "description": "Branch to delete the file from"
+            },
+            "message": {
+              "type": "string",
+              "description": "Commit message"
+            },
+            "owner": {
+              "type": "string",
+              "description": "Repository owner (username or organization)"
+            },
+            "path": {
+              "type": "string",
+              "description": "Path to the file to delete"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            }
+          },
+          "required": [
+            "owner",
+            "repo",
+            "path",
+            "message",
+            "branch"
+          ]
+        },
+        "annotations": {
+          "title": "Delete file",
+          "destructiveHint": true
+        }
+      },
+      {
+        "name": "fork_repository",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACuElEQVRIibWTTUhUYRiFn/fOdYyoydQxk4LEGzN3RudaLYL+qRaBQYsIItoHCW37ISNbRwUFLWoRZBEt+4EIooKoTdZQ6TWaNIgouzJkuGhG731b6JTojDNBntX3ne+c97zfH8wzZCbREm9bZ4hsQvkeDvl3+/r6xuYqEIvFFgdSvRuDqCrPMu6bVyUDrITTjdI1jR8KBbrj/fs3Q8WLp5p9Qx4BzVOUInIm058+XdAY0ztH6RLhSpAza1RlI2jENzhfqntfjAugEdTYMFEtS0GvonrKslNrZwWIhDYDMh6Wo4ODvaMfB9LPFaMHZGvJ8xHdAlzPDLx+8Smd/pE39SggAptnB2gwDBD6ReJvhSCpMFyq/uSa/NFX5UMJgGCaxywMwiH/bi4wh0SCOy1x5waiCUF2gnSW3AByEfSSZTsPVXFF9CDC4ALx7xU0ocLA87x8tG7ZHRUShsheVMKInMy46culArIj317WRpd7KB2GsAl4bKoccN2330t5ALBsJ7ASTvecoun6hNNt2U5QbM0oRip8E6Wt0gCUFPC12FKoGFnX0BgBDtVGG3/W1qzqz2a/5IrpLGt9pLahvhPhCKrnsiPDT2dqZv1kgGQyGc4FZg+wr8I93F6y0DzY29s7XlHAnw7j7dswgg2oRCYZPTBluzk51VEwXmQG0k8qbGRuWHbqiWWn/qlY0Uv+n5j3gKKvaCaSyeSimrqms4hsB4kurW9c0bSs/pnneflyXrOcACCn5jWEPSr0AAgczvlVTVT+ykojFlvTZNmOWvHU8QJnJVInLNtR2163vJy/7B0EpjYAqBhugVMVF8A3goZy/rJHFGa8P4fpCXosHm9PqwbiwzHAqyLvlvPP+dEKWG23dyh6C1g0RY0Jsv+Dm77/XwIAWlpbVzJh7gLAnHjw8d27z5V65xW/AVGM6Ekx9nZCAAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABoUlEQVRIibWUPS+EQRSFz0hsxaIgIZHYllDYiiiUEn6Bn0Dho6Nhf4GPjkYn8ZEgGqFRSNBoVTQKdhEROsk+mrt2svvu7Gutk7yZzJlz77nzztyR/hmulADSkkYk5SQdO+c+QwmAZkkTktolXTjnbkLiDJCniHsgFdCnTFNAHliuJE6bYANoAYaBF+AwYHBkmiGgFdi0HINR4lmrotXjVoG3gMEbsOLN2yzHTIFr8PRZG3s9rs/jo5At0fd6fFk1TfY/X4A14MyqmQrsYNo0pxbzCtwBTZUCUsAh8GHCKaDspnl6ZyZ3FnMA9AR2/BOYBzJVhUV9BshHrTVEkZKeJPXHNZA0IOkxttrrhzkgGdAlgXnTLv3GIAHsEh87QGNUrooHaEajkoYlFXYxaeO2je+SLp1z57Grr2J4DvwqWaVDrhv+3SAWrMvXgWcgZ10b3a01GuwDX8CWfV/AXr2Sd9lVXPC4ReM6q8XHOYMOG2897rZkrXZY0+WAK6DHHsRr4xJ/NjCTcXstC/gAxuPEBju5xKRb0phNT5xzD7UUW3d8A4p92DZKdSwEAAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Fork a GitHub repository to your account or specified organization",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "organization": {
+              "type": "string",
+              "description": "Organization to fork to"
+            },
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            }
+          },
+          "required": [
+            "owner",
+            "repo"
+          ]
+        },
+        "annotations": {
+          "title": "Fork repository"
+        }
+      },
+      {
+        "name": "get_commit",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Get details for a commit from a GitHub repository",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "include_diff": {
+              "type": "boolean",
+              "description": "Whether to include file diffs and stats in the response. Default is true.",
+              "default": true
+            },
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "page": {
+              "type": "number",
+              "description": "Page number for pagination (min 1)",
+              "minimum": 1
+            },
+            "perPage": {
+              "type": "number",
+              "description": "Results per page for pagination (min 1, max 100)",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            },
+            "sha": {
+              "type": "string",
+              "description": "Commit SHA, branch name, or tag name"
+            }
+          },
+          "required": [
+            "owner",
+            "repo",
+            "sha"
+          ]
+        },
+        "annotations": {
+          "title": "Get commit details",
+          "readOnlyHint": true
+        }
+      },
+      {
+        "name": "get_copilot_job_status",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAC20lEQVRIidWUS4wMURSGv3O7kWmPEMRrSMzcbl1dpqtmGuOxsCKECCKxEBusSJhIWEhsWLFAbC1sWFiISBARCyQ2kzSZGaMxHokgXvGIiMH0PRZjpJqqHpb+TeX+59z//H/q5sD/DqlX9H1/zFeX2qzIKoFWYDKgwBtUymL0UkNaT3V3d3/+5wG2EGxB9TDIxGFMvhVhb9/drpN/NaDJC7MGdwJk6TDCv0Gvq0lve9R762GUNdFDLleaZNBrICGq+4yhvf9TJtP/KZNB2PrLlbBliBfRhajuAwnFVa/n8/nkxFkv3GO9oJrzgwVxdesV71ov6I2r5fxggfWCatYL9yYmUJgLPH7Q29WZ4OED6Me4wuAdeQK6MMqna9t0GuibBHFAmgZ9JMG9BhkXZWoSCDSATIq7aguBD0wBplq/tZBgYDIwKnZAs99mFRYD9vd/YK0dpcqhobM6d9haWyOULRTbAauwuNlvsxHTYP3iBnVyXGAa8BIYC3oVeAKioCtAPEE7FCOgR0ErIJdBBZgNskzh40+NF6K6s+9e91lp9osrxMnFoTSmSmPVsF+E5cB0YEDgtoMjjypd5wCy+WC9GnajhEAa4bkqV9LOHKwa9/yneYeyUqwX3AdyQ5EeVrrqro/hYL0g+ggemKh4HGbPmVu0+fB8U76lpR6XgJwZpoGUpNYiusZg1tXjkmCAav0OMTXfJC4eVYPqwbot6l4BCPqyLhd7lwMAWC/cYb3gi/UCzRaKOxsbFzVEM1iv2Ebt5v2Dm14qZbJecZf1Ah3UCrcTbbB+awHnjgHLgHeinHYqZ8aPSXWWy+XvcQZLpdKI9/0D7UbZiLIJmABckVSqo+/OrUrNgF+D8q1LEdcBrAJGAJ8ROlGeicorABWdAswE5gOjge8CF8Ad66v03IjqJb75WS0tE0YOmNWqLBGReaAzgIkMLrt3oM9UpSzCzW9pd+FpT8/7JK3/Gz8Ao5X6wtwP7N4AAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACCElEQVRIid2UPWsUYRSFn3dxWWJUkESiBgslFokfhehGiGClBBQx4h9IGlEh2ijYxh+gxEL/hIWwhYpF8KNZsFRJYdJEiUbjCkqisj4W+y6Mk5nd1U4PDMOce+45L3fmDvzXUDeo59WK+kb9rn5TF9R76jm1+2/NJ9QPtseSOv4nxrvVmQ6M05hRB9qZ98ZR1NRralntitdEwmw8wQ9HbS329rQKuKLW1XJO/aX6IqdWjr1Xk/y6lG4vMBdCqOacoZZ3uBBCVZ0HDrcK2AYs5ZkAuwBb1N8Dm5JEISXoAnqzOtU9QB+wVR3KCdgClDIr6kCc4c/0O1BLNnahiYpaSmmGY62e/JpCLJ4FpmmMaBHYCDwC5mmMZBQYBC7HnhvAK+B+fN4JHAM+R4+3wGQI4S7qaExtol+9o86pq+oX9Yk6ljjtGfVprK2qr9Xb6vaET109jjqb3Jac2XaM1PLNpok1Aep+G/+dfa24nADTX1EWTgOngLE2XCYKQL0DTfKex2WhXgCutxG9i/fFNlwWpgBQL6orcWyTaldToRbUA2pow61XL0WPFfXCb1HqkPowCj6q0+qIWsw7nlpUj6i31OXY+0AdbGpCRtNRGgt1AigCX4EqsJAYTR+wAzgEdAM/gApwM4TwOOm3JiARtBk4CYwAB4F+oIfGZi/HwOfAM6ASQviU5/Vv4xcBzmW2eT1nrQAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Get the status of a GitHub Copilot coding agent job. Use this to check if a previously submitted task has completed and to get the pull request URL once it's created. Provide the job ID (from create_pull_request_with_copilot) or pull request number (from assign_copilot_to_issue), or any pull request you want agent sessions for.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Job ID or pull request number"
+            },
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            }
+          },
+          "required": [
+            "owner",
+            "repo",
+            "id"
+          ]
+        },
+        "annotations": {
+          "title": "Get Copilot coding agent job status",
+          "readOnlyHint": true,
+          "openWorldHint": false
+        }
+      },
+      {
+        "name": "get_file_contents",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Get the contents of a file or directory from a GitHub repository",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "owner": {
+              "type": "string",
+              "description": "Repository owner (username or organization)"
+            },
+            "path": {
+              "type": "string",
+              "description": "Path to file/directory",
+              "default": "/"
+            },
+            "ref": {
+              "type": "string",
+              "description": "Accepts optional git refs such as `refs/tags/{tag}`, `refs/heads/{branch}` or `refs/pull/{pr_number}/head`"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            },
+            "sha": {
+              "type": "string",
+              "description": "Accepts optional commit SHA. If specified, it will be used instead of ref"
+            }
+          },
+          "required": [
+            "owner",
+            "repo"
+          ]
+        },
+        "annotations": {
+          "title": "Get file or directory contents",
+          "readOnlyHint": true
+        }
+      },
+      {
+        "name": "get_label",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAC2UlEQVRIicWVMUyTaRjHf/+vVUpOJOdilOYoUvVreq2CDmLOwdlAS5xMbrrhBifjYG7QjYuJw108nZx1huLgYlw0QshxChUK2koxHHcuCmgsFfieG0or3kGPSoz/8X3f5/97nvfN8z7wmaVqm9FodFfR/EnMugy5giCAwYwgI9Ff9Hl9L9Lp1zUBgsGO+rqGwnlhF4CdwBSyAUwvS1G220zHBSFgHtmVxYWvfp2ZGSj8LyAcjgfZphTQZtAr7OdsZvSP9RIJR+LtQhcNusF+d1aUfPp05M8NAavmg8AOk3cmN56+s1Hpa7U/cviUYbcw3jgex9ZCKoBgsKM+0PDuAdBq2He5zOiTzZiXtc+NxRw598GeLRcWTuTz+UUAp3ygrqFwHmgzeWdqNQd4PpFOy/gedNQfaDz3UQXRaHRX0fNPGdzNZUZO12q+VuHIoV7g5Hu/1/IinX7tABTNnwR2SvRsxRzAzOsBGuuWfAkoX5FZFzCVHR95tFVAbiI9DEwj6wLwl5YVMTRYLTDsxjuRrgGYYz/kxkbvbXRWMOBB24cKYI9ks1X8hXQDaAaa5XG9WjImZgV71wI+m8qAv8y0t1pSmP0ITANTmHO2qqvRZDALlTdgHKyjWkx2YvQ2cHtTacMxYBhWK5DoF4TCkXj7Jg02VKsbOwI0Y+qvALZrOQXMC13cKkDSJWBuJUCqAhgbG3uF7IpBcn/k8KlPNQ+78U5QQuhy/vHjuQoAYPndwi9gw4bd2ufGYrWatxz8No50ExhaKsz9Vl6vAPL5/KKzoiTGG0fOg1oqCbvxTp/juw/M+zynu/yTwjoD58CBQ02ez/pAR4E+M69ntf3/o1Y3dqR050oAQz7P6Z6cfPRRw647MkOhUMAfaDyH+AloBKYNPRT292rQHoMOSp09J3TZlt5ezWazxX97VR3638RiX9ct+RImSyBcrDT0ETMyMp4ptRIgVX7QL6J/ALSUEwJ5rdg2AAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABxElEQVRIibWVvW4TURCFv0vlNEDcIHAkKAERJOIKSjoUArwBPwUFFaKIIngAJARCPIgdh4cgRBYt6ZIAEYEqdhpEw0fhCbkKa68dxyNtsfNzzpnZu3NhwpYGBdUqcA+4A1wEZiK0DawD74FWSml3JAJ1CngGLAIngU1gFfgZKWeAG8AFoAu8At6mlH6VtqTOqJ/UP2pDnRuQO6c27VlbrQ0Dvq121Fulag7q5qPmW18SdSqUd9Qrw4Jn9bNR21YrRQkvYixDKy/AuB3jWjocqKpdtXFU8AxrOTqZzp2PgvnaMRDUA+tB7mypG+OCZ3hbahPgRPguAR9LihaicEu9WcKxClzOi/fU1wPAk7rjgX0uEfNG3cs7mJjtE+wA5/olpZQEHgNf6K2NJyW4NeD7v7c4WptjSc0svlMjdzyM2fbdOyOA7x/T+7mzGj9H8xgIWuquevpw4HmsivkxwBdC/WJRsBKLqqPOHgH8aqybtcJlF0m1WLndUToJ5V31q9r3NOYk7Wh1Wa0PyK3HzA3l/4H3uzIrwFNgCThF7/x/AH5EylngOnAe6AAvgXcppd9DEWRE08DdeIou/RVgJaXUGYQzUfsL+zmwV7BtIq0AAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Get a specific label from a repository.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Label name."
+            },
+            "owner": {
+              "type": "string",
+              "description": "Repository owner (username or organization name)"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            }
+          },
+          "required": [
+            "owner",
+            "repo",
+            "name"
+          ]
+        },
+        "annotations": {
+          "title": "Get a specific label from a repository.",
+          "readOnlyHint": true
+        }
+      },
+      {
+        "name": "get_latest_release",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Get the latest release in a GitHub repository",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            }
+          },
+          "required": [
+            "owner",
+            "repo"
+          ]
+        },
+        "annotations": {
+          "title": "Get latest release",
+          "readOnlyHint": true
+        }
+      },
+      {
+        "name": "get_me",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACSUlEQVRIidWVv09TURTHP+e+2mJMEOLiQBig4GtN4WEHRQxGMfHHYkx0YpJJR+OmjMTNP0CjRv4DJyNETXTQODRQSkmJTweYBUw0KeX1HoeCKY3v0eKi3/Gdc74/zrs3F/53SJN9Jul6owhpAJQlvzT/HrB/LZB0h4YR+wjI7B6UBVW55ZfmPkY6a4J8FugQ1euOLbc7ttyuyDWLJhA7k0wNnNpvAulLefOKdiZM4BWLxbX6Yncm0xkPTB5lzS/lhwBtKUHS9c4qOiCqdxrJAVYKhXVE7iIMJt2h0TCe8BVt/1Cjm7OhPZXETK23mm5ZQMTGQom3YW0gACoS2hsqoNbJAwTm4FjocFtwEcCozYcajTBo+lLenEUTWzE7vFIorNcXXdc9EpCYB775pfwJQu5E1BqsVW6L8CoemHwy7d39vfN4+VJgeYhwGPRGGPleCQCkN+XdE3Tqz1W97y8tPIgkCCv092dc68gzkGFgHXiNsFrLJt2IjgGdwAfH6sTy8sJy0wK9xwbPieEFSlmRyY5DzvNcLrdV35PNZg9s/KzeFNEpII6aq35p7t2eAjXn5hOwqk718pfFxdXQ/EDP8Wy3scFLoMuxerIxSeMxFeuYpyjlZsgBvhZzK9bErgAVa+RJo+ldAn0p7wJwWpHJZsjrRVRlUuFMT3rgfEQCOw5stDlb082S70CCH9PAd2NlPFRAkRGEN8VisdKqgO/7mwJvEUZCBYCjwOdWyXdga7Nd9d9232SRCSo28oWKgjjVxxrElvY7/2/iF/Bu47CZ2fOnAAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABaElEQVRIidWUvUrDcBTFz79YnRSii4N2cVB8AuvgByKuQqmrILQPoe9SfABxV5wUna2IVLq1k11adffn4A3UNPknjQ56IARyzz3ncj8i/Xe4LCSgIGlD0qp9epJ07Zz7+HEFQBl4YBRNoPwb4u9AB6gA0/bsAy3gDVjLK+6syg4wGxMPLHYPZGp1VGDLWlHxcKrG2UziFDwe4UAvPZyLCHcsgwlPLETYmkSuz6Bp7x0PZy/CzQ6gYENuAUFMfA7o2pB9hXpN1m0VOzbQGXsOTDz/mpqBA05ijizEcZpG4v4CK5IaksqS+pKuJHUtXNLXbAJJd5KOnHPP41S+DbwCL0ANKMZwikAd6AED3y2MVG7ij8BiBn7JuANgOY3sgFurPFU8YtIDbry/DWDXhlfLKj6UW7fc5LsBToE+MJnDYMra1PCR2sDZuOJD+efAt22KXuC8pHZeA8td8FVQBZIJKQCWgMO8+X8Tn12zhtgfmPjeAAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Get details of the authenticated GitHub user. Use this when a request is about the user's own profile for GitHub. Or when information is missing to build other tool calls.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        },
+        "annotations": {
+          "title": "Get my user profile",
+          "readOnlyHint": true
+        }
+      },
+      {
+        "name": "get_release_by_tag",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Get a specific release by its tag name in a GitHub repository",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            },
+            "tag": {
+              "type": "string",
+              "description": "Tag name (e.g., 'v1.0.0')"
+            }
+          },
+          "required": [
+            "owner",
+            "repo",
+            "tag"
+          ]
+        },
+        "annotations": {
+          "title": "Get a release by tag name",
+          "readOnlyHint": true
+        }
+      },
+      {
+        "name": "get_tag",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Get details about a specific git tag in a GitHub repository",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            },
+            "tag": {
+              "type": "string",
+              "description": "Tag name"
+            }
+          },
+          "required": [
+            "owner",
+            "repo",
+            "tag"
+          ]
+        },
+        "annotations": {
+          "title": "Get tag details",
+          "readOnlyHint": true
+        }
+      },
+      {
+        "name": "get_team_members",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACSUlEQVRIidWVv09TURTHP+e+2mJMEOLiQBig4GtN4WEHRQxGMfHHYkx0YpJJR+OmjMTNP0CjRv4DJyNETXTQODRQSkmJTweYBUw0KeX1HoeCKY3v0eKi3/Gdc74/zrs3F/53SJN9Jul6owhpAJQlvzT/HrB/LZB0h4YR+wjI7B6UBVW55ZfmPkY6a4J8FugQ1euOLbc7ttyuyDWLJhA7k0wNnNpvAulLefOKdiZM4BWLxbX6Yncm0xkPTB5lzS/lhwBtKUHS9c4qOiCqdxrJAVYKhXVE7iIMJt2h0TCe8BVt/1Cjm7OhPZXETK23mm5ZQMTGQom3YW0gACoS2hsqoNbJAwTm4FjocFtwEcCozYcajTBo+lLenEUTWzE7vFIorNcXXdc9EpCYB775pfwJQu5E1BqsVW6L8CoemHwy7d39vfN4+VJgeYhwGPRGGPleCQCkN+XdE3Tqz1W97y8tPIgkCCv092dc68gzkGFgHXiNsFrLJt2IjgGdwAfH6sTy8sJy0wK9xwbPieEFSlmRyY5DzvNcLrdV35PNZg9s/KzeFNEpII6aq35p7t2eAjXn5hOwqk718pfFxdXQ/EDP8Wy3scFLoMuxerIxSeMxFeuYpyjlZsgBvhZzK9bErgAVa+RJo+ldAn0p7wJwWpHJZsjrRVRlUuFMT3rgfEQCOw5stDlb082S70CCH9PAd2NlPFRAkRGEN8VisdKqgO/7mwJvEUZCBYCjwOdWyXdga7Nd9d9232SRCSo28oWKgjjVxxrElvY7/2/iF/Bu47CZ2fOnAAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABaElEQVRIidWUvUrDcBTFz79YnRSii4N2cVB8AuvgByKuQqmrILQPoe9SfABxV5wUna2IVLq1k11adffn4A3UNPknjQ56IARyzz3ncj8i/Xe4LCSgIGlD0qp9epJ07Zz7+HEFQBl4YBRNoPwb4u9AB6gA0/bsAy3gDVjLK+6syg4wGxMPLHYPZGp1VGDLWlHxcKrG2UziFDwe4UAvPZyLCHcsgwlPLETYmkSuz6Bp7x0PZy/CzQ6gYENuAUFMfA7o2pB9hXpN1m0VOzbQGXsOTDz/mpqBA05ijizEcZpG4v4CK5IaksqS+pKuJHUtXNLXbAJJd5KOnHPP41S+DbwCL0ANKMZwikAd6AED3y2MVG7ij8BiBn7JuANgOY3sgFurPFU8YtIDbry/DWDXhlfLKj6UW7fc5LsBToE+MJnDYMra1PCR2sDZuOJD+efAt22KXuC8pHZeA8td8FVQBZIJKQCWgMO8+X8Tn12zhtgfmPjeAAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Get member usernames of a specific team in an organization. Limited to organizations accessible with current credentials",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "org": {
+              "type": "string",
+              "description": "Organization login (owner) that contains the team."
+            },
+            "team_slug": {
+              "type": "string",
+              "description": "Team slug"
+            }
+          },
+          "required": [
+            "org",
+            "team_slug"
+          ]
+        },
+        "annotations": {
+          "title": "Get team members",
+          "readOnlyHint": true
+        }
+      },
+      {
+        "name": "get_teams",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACSUlEQVRIidWVv09TURTHP+e+2mJMEOLiQBig4GtN4WEHRQxGMfHHYkx0YpJJR+OmjMTNP0CjRv4DJyNETXTQODRQSkmJTweYBUw0KeX1HoeCKY3v0eKi3/Gdc74/zrs3F/53SJN9Jul6owhpAJQlvzT/HrB/LZB0h4YR+wjI7B6UBVW55ZfmPkY6a4J8FugQ1euOLbc7ttyuyDWLJhA7k0wNnNpvAulLefOKdiZM4BWLxbX6Yncm0xkPTB5lzS/lhwBtKUHS9c4qOiCqdxrJAVYKhXVE7iIMJt2h0TCe8BVt/1Cjm7OhPZXETK23mm5ZQMTGQom3YW0gACoS2hsqoNbJAwTm4FjocFtwEcCozYcajTBo+lLenEUTWzE7vFIorNcXXdc9EpCYB775pfwJQu5E1BqsVW6L8CoemHwy7d39vfN4+VJgeYhwGPRGGPleCQCkN+XdE3Tqz1W97y8tPIgkCCv092dc68gzkGFgHXiNsFrLJt2IjgGdwAfH6sTy8sJy0wK9xwbPieEFSlmRyY5DzvNcLrdV35PNZg9s/KzeFNEpII6aq35p7t2eAjXn5hOwqk718pfFxdXQ/EDP8Wy3scFLoMuxerIxSeMxFeuYpyjlZsgBvhZzK9bErgAVa+RJo+ldAn0p7wJwWpHJZsjrRVRlUuFMT3rgfEQCOw5stDlb082S70CCH9PAd2NlPFRAkRGEN8VisdKqgO/7mwJvEUZCBYCjwOdWyXdga7Nd9d9232SRCSo28oWKgjjVxxrElvY7/2/iF/Bu47CZ2fOnAAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABaElEQVRIidWUvUrDcBTFz79YnRSii4N2cVB8AuvgByKuQqmrILQPoe9SfABxV5wUna2IVLq1k11adffn4A3UNPknjQ56IARyzz3ncj8i/Xe4LCSgIGlD0qp9epJ07Zz7+HEFQBl4YBRNoPwb4u9AB6gA0/bsAy3gDVjLK+6syg4wGxMPLHYPZGp1VGDLWlHxcKrG2UziFDwe4UAvPZyLCHcsgwlPLETYmkSuz6Bp7x0PZy/CzQ6gYENuAUFMfA7o2pB9hXpN1m0VOzbQGXsOTDz/mpqBA05ijizEcZpG4v4CK5IaksqS+pKuJHUtXNLXbAJJd5KOnHPP41S+DbwCL0ANKMZwikAd6AED3y2MVG7ij8BiBn7JuANgOY3sgFurPFU8YtIDbry/DWDXhlfLKj6UW7fc5LsBToE+MJnDYMra1PCR2sDZuOJD+efAt22KXuC8pHZeA8td8FVQBZIJKQCWgMO8+X8Tn12zhtgfmPjeAAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Get details of the teams the user is a member of. Limited to organizations accessible with current credentials",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "user": {
+              "type": "string",
+              "description": "Username to get teams for. If not provided, uses the authenticated user."
+            }
+          }
+        },
+        "annotations": {
+          "title": "Get teams",
+          "readOnlyHint": true
+        }
+      },
+      {
+        "name": "issue_read",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAC2UlEQVRIicWVMUyTaRjHf/+vVUpOJOdilOYoUvVreq2CDmLOwdlAS5xMbrrhBifjYG7QjYuJw108nZx1huLgYlw0QshxChUK2koxHHcuCmgsFfieG0or3kGPSoz/8X3f5/97nvfN8z7wmaVqm9FodFfR/EnMugy5giCAwYwgI9Ff9Hl9L9Lp1zUBgsGO+rqGwnlhF4CdwBSyAUwvS1G220zHBSFgHtmVxYWvfp2ZGSj8LyAcjgfZphTQZtAr7OdsZvSP9RIJR+LtQhcNusF+d1aUfPp05M8NAavmg8AOk3cmN56+s1Hpa7U/cviUYbcw3jgex9ZCKoBgsKM+0PDuAdBq2He5zOiTzZiXtc+NxRw598GeLRcWTuTz+UUAp3ygrqFwHmgzeWdqNQd4PpFOy/gedNQfaDz3UQXRaHRX0fNPGdzNZUZO12q+VuHIoV7g5Hu/1/IinX7tABTNnwR2SvRsxRzAzOsBGuuWfAkoX5FZFzCVHR95tFVAbiI9DEwj6wLwl5YVMTRYLTDsxjuRrgGYYz/kxkbvbXRWMOBB24cKYI9ks1X8hXQDaAaa5XG9WjImZgV71wI+m8qAv8y0t1pSmP0ITANTmHO2qqvRZDALlTdgHKyjWkx2YvQ2cHtTacMxYBhWK5DoF4TCkXj7Jg02VKsbOwI0Y+qvALZrOQXMC13cKkDSJWBuJUCqAhgbG3uF7IpBcn/k8KlPNQ+78U5QQuhy/vHjuQoAYPndwi9gw4bd2ufGYrWatxz8No50ExhaKsz9Vl6vAPL5/KKzoiTGG0fOg1oqCbvxTp/juw/M+zynu/yTwjoD58CBQ02ez/pAR4E+M69ntf3/o1Y3dqR050oAQz7P6Z6cfPRRw647MkOhUMAfaDyH+AloBKYNPRT292rQHoMOSp09J3TZlt5ezWazxX97VR3638RiX9ct+RImSyBcrDT0ETMyMp4ptRIgVX7QL6J/ALSUEwJ5rdg2AAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABxElEQVRIibWVvW4TURCFv0vlNEDcIHAkKAERJOIKSjoUArwBPwUFFaKIIngAJARCPIgdh4cgRBYt6ZIAEYEqdhpEw0fhCbkKa68dxyNtsfNzzpnZu3NhwpYGBdUqcA+4A1wEZiK0DawD74FWSml3JAJ1CngGLAIngU1gFfgZKWeAG8AFoAu8At6mlH6VtqTOqJ/UP2pDnRuQO6c27VlbrQ0Dvq121Fulag7q5qPmW18SdSqUd9Qrw4Jn9bNR21YrRQkvYixDKy/AuB3jWjocqKpdtXFU8AxrOTqZzp2PgvnaMRDUA+tB7mypG+OCZ3hbahPgRPguAR9LihaicEu9WcKxClzOi/fU1wPAk7rjgX0uEfNG3cs7mJjtE+wA5/olpZQEHgNf6K2NJyW4NeD7v7c4WptjSc0svlMjdzyM2fbdOyOA7x/T+7mzGj9H8xgIWuquevpw4HmsivkxwBdC/WJRsBKLqqPOHgH8aqybtcJlF0m1WLndUToJ5V31q9r3NOYk7Wh1Wa0PyK3HzA3l/4H3uzIrwFNgCThF7/x/AH5EylngOnAe6AAvgXcppd9DEWRE08DdeIou/RVgJaXUGYQzUfsL+zmwV7BtIq0AAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Get information about a specific issue in a GitHub repository.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "issue_number": {
+              "type": "number",
+              "description": "The number of the issue"
+            },
+            "method": {
+              "type": "string",
+              "description": "The read operation to perform on a single issue.\nOptions are:\n1. get - Get details of a specific issue.\n2. get_comments - Get issue comments.\n3. get_sub_issues - Get sub-issues of the issue.\n4. get_labels - Get labels assigned to the issue.\n",
+              "enum": [
+                "get",
+                "get_comments",
+                "get_sub_issues",
+                "get_labels"
+              ]
+            },
+            "owner": {
+              "type": "string",
+              "description": "The owner of the repository"
+            },
+            "page": {
+              "type": "number",
+              "description": "Page number for pagination (min 1)",
+              "minimum": 1
+            },
+            "perPage": {
+              "type": "number",
+              "description": "Results per page for pagination (min 1, max 100)",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "repo": {
+              "type": "string",
+              "description": "The name of the repository"
+            }
+          },
+          "required": [
+            "method",
+            "owner",
+            "repo",
+            "issue_number"
+          ]
+        },
+        "annotations": {
+          "title": "Get issue details",
+          "readOnlyHint": true
+        }
+      },
+      {
+        "name": "issue_write",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAC2UlEQVRIicWVMUyTaRjHf/+vVUpOJOdilOYoUvVreq2CDmLOwdlAS5xMbrrhBifjYG7QjYuJw108nZx1huLgYlw0QshxChUK2koxHHcuCmgsFfieG0or3kGPSoz/8X3f5/97nvfN8z7wmaVqm9FodFfR/EnMugy5giCAwYwgI9Ff9Hl9L9Lp1zUBgsGO+rqGwnlhF4CdwBSyAUwvS1G220zHBSFgHtmVxYWvfp2ZGSj8LyAcjgfZphTQZtAr7OdsZvSP9RIJR+LtQhcNusF+d1aUfPp05M8NAavmg8AOk3cmN56+s1Hpa7U/cviUYbcw3jgex9ZCKoBgsKM+0PDuAdBq2He5zOiTzZiXtc+NxRw598GeLRcWTuTz+UUAp3ygrqFwHmgzeWdqNQd4PpFOy/gedNQfaDz3UQXRaHRX0fNPGdzNZUZO12q+VuHIoV7g5Hu/1/IinX7tABTNnwR2SvRsxRzAzOsBGuuWfAkoX5FZFzCVHR95tFVAbiI9DEwj6wLwl5YVMTRYLTDsxjuRrgGYYz/kxkbvbXRWMOBB24cKYI9ks1X8hXQDaAaa5XG9WjImZgV71wI+m8qAv8y0t1pSmP0ITANTmHO2qqvRZDALlTdgHKyjWkx2YvQ2cHtTacMxYBhWK5DoF4TCkXj7Jg02VKsbOwI0Y+qvALZrOQXMC13cKkDSJWBuJUCqAhgbG3uF7IpBcn/k8KlPNQ+78U5QQuhy/vHjuQoAYPndwi9gw4bd2ufGYrWatxz8No50ExhaKsz9Vl6vAPL5/KKzoiTGG0fOg1oqCbvxTp/juw/M+zynu/yTwjoD58CBQ02ez/pAR4E+M69ntf3/o1Y3dqR050oAQz7P6Z6cfPRRw647MkOhUMAfaDyH+AloBKYNPRT292rQHoMOSp09J3TZlt5ezWazxX97VR3638RiX9ct+RImSyBcrDT0ETMyMp4ptRIgVX7QL6J/ALSUEwJ5rdg2AAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABxElEQVRIibWVvW4TURCFv0vlNEDcIHAkKAERJOIKSjoUArwBPwUFFaKIIngAJARCPIgdh4cgRBYt6ZIAEYEqdhpEw0fhCbkKa68dxyNtsfNzzpnZu3NhwpYGBdUqcA+4A1wEZiK0DawD74FWSml3JAJ1CngGLAIngU1gFfgZKWeAG8AFoAu8At6mlH6VtqTOqJ/UP2pDnRuQO6c27VlbrQ0Dvq121Fulag7q5qPmW18SdSqUd9Qrw4Jn9bNR21YrRQkvYixDKy/AuB3jWjocqKpdtXFU8AxrOTqZzp2PgvnaMRDUA+tB7mypG+OCZ3hbahPgRPguAR9LihaicEu9WcKxClzOi/fU1wPAk7rjgX0uEfNG3cs7mJjtE+wA5/olpZQEHgNf6K2NJyW4NeD7v7c4WptjSc0svlMjdzyM2fbdOyOA7x/T+7mzGj9H8xgIWuquevpw4HmsivkxwBdC/WJRsBKLqqPOHgH8aqybtcJlF0m1WLndUToJ5V31q9r3NOYk7Wh1Wa0PyK3HzA3l/4H3uzIrwFNgCThF7/x/AH5EylngOnAe6AAvgXcppd9DEWRE08DdeIou/RVgJaXUGYQzUfsL+zmwV7BtIq0AAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Create a new or update an existing issue in a GitHub repository.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "assignees": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Usernames to assign to this issue"
+            },
+            "body": {
+              "type": "string",
+              "description": "Issue body content"
+            },
+            "duplicate_of": {
+              "type": "number",
+              "description": "Issue number that this issue is a duplicate of. Only used when state_reason is 'duplicate'."
+            },
+            "issue_number": {
+              "type": "number",
+              "description": "Issue number to update"
+            },
+            "labels": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Labels to apply to this issue"
+            },
+            "method": {
+              "type": "string",
+              "description": "Write operation to perform on a single issue.\nOptions are:\n- 'create' - creates a new issue.\n- 'update' - updates an existing issue.\n",
+              "enum": [
+                "create",
+                "update"
+              ]
+            },
+            "milestone": {
+              "type": "number",
+              "description": "Milestone number"
+            },
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            },
+            "state": {
+              "type": "string",
+              "description": "New state",
+              "enum": [
+                "open",
+                "closed"
+              ]
+            },
+            "state_reason": {
+              "type": "string",
+              "description": "Reason for the state change. Ignored unless state is changed.",
+              "enum": [
+                "completed",
+                "not_planned",
+                "duplicate"
+              ]
+            },
+            "title": {
+              "type": "string",
+              "description": "Issue title"
+            },
+            "type": {
+              "type": "string",
+              "description": "Type of this issue. Only use if the repository has issue types configured. Use list_issue_types tool to get valid type values for the organization. If the repository doesn't support issue types, omit this parameter."
+            }
+          },
+          "required": [
+            "method",
+            "owner",
+            "repo"
+          ]
+        },
+        "annotations": {
+          "title": "Create or update issue."
+        }
+      },
+      {
+        "name": "list_branches",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "List branches in a GitHub repository",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "page": {
+              "type": "number",
+              "description": "Page number for pagination (min 1)",
+              "minimum": 1
+            },
+            "perPage": {
+              "type": "number",
+              "description": "Results per page for pagination (min 1, max 100)",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            }
+          },
+          "required": [
+            "owner",
+            "repo"
+          ]
+        },
+        "annotations": {
+          "title": "List branches",
+          "readOnlyHint": true
+        }
+      },
+      {
+        "name": "list_commits",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Get list of commits of a branch in a GitHub repository. Returns at least 30 results per page by default, but can return more if specified using the perPage parameter (up to 100).",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "author": {
+              "type": "string",
+              "description": "Author username or email address to filter commits by"
+            },
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "page": {
+              "type": "number",
+              "description": "Page number for pagination (min 1)",
+              "minimum": 1
+            },
+            "perPage": {
+              "type": "number",
+              "description": "Results per page for pagination (min 1, max 100)",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            },
+            "sha": {
+              "type": "string",
+              "description": "Commit SHA, branch or tag name to list commits of. If not provided, uses the default branch of the repository. If a commit SHA is provided, will list commits up to that SHA."
+            }
+          },
+          "required": [
+            "owner",
+            "repo"
+          ]
+        },
+        "annotations": {
+          "title": "List commits",
+          "readOnlyHint": true
+        }
+      },
+      {
+        "name": "list_issue_types",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAC2UlEQVRIicWVMUyTaRjHf/+vVUpOJOdilOYoUvVreq2CDmLOwdlAS5xMbrrhBifjYG7QjYuJw108nZx1huLgYlw0QshxChUK2koxHHcuCmgsFfieG0or3kGPSoz/8X3f5/97nvfN8z7wmaVqm9FodFfR/EnMugy5giCAwYwgI9Ff9Hl9L9Lp1zUBgsGO+rqGwnlhF4CdwBSyAUwvS1G220zHBSFgHtmVxYWvfp2ZGSj8LyAcjgfZphTQZtAr7OdsZvSP9RIJR+LtQhcNusF+d1aUfPp05M8NAavmg8AOk3cmN56+s1Hpa7U/cviUYbcw3jgex9ZCKoBgsKM+0PDuAdBq2He5zOiTzZiXtc+NxRw598GeLRcWTuTz+UUAp3ygrqFwHmgzeWdqNQd4PpFOy/gedNQfaDz3UQXRaHRX0fNPGdzNZUZO12q+VuHIoV7g5Hu/1/IinX7tABTNnwR2SvRsxRzAzOsBGuuWfAkoX5FZFzCVHR95tFVAbiI9DEwj6wLwl5YVMTRYLTDsxjuRrgGYYz/kxkbvbXRWMOBB24cKYI9ks1X8hXQDaAaa5XG9WjImZgV71wI+m8qAv8y0t1pSmP0ITANTmHO2qqvRZDALlTdgHKyjWkx2YvQ2cHtTacMxYBhWK5DoF4TCkXj7Jg02VKsbOwI0Y+qvALZrOQXMC13cKkDSJWBuJUCqAhgbG3uF7IpBcn/k8KlPNQ+78U5QQuhy/vHjuQoAYPndwi9gw4bd2ufGYrWatxz8No50ExhaKsz9Vl6vAPL5/KKzoiTGG0fOg1oqCbvxTp/juw/M+zynu/yTwjoD58CBQ02ez/pAR4E+M69ntf3/o1Y3dqR050oAQz7P6Z6cfPRRw647MkOhUMAfaDyH+AloBKYNPRT292rQHoMOSp09J3TZlt5ezWazxX97VR3638RiX9ct+RImSyBcrDT0ETMyMp4ptRIgVX7QL6J/ALSUEwJ5rdg2AAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABxElEQVRIibWVvW4TURCFv0vlNEDcIHAkKAERJOIKSjoUArwBPwUFFaKIIngAJARCPIgdh4cgRBYt6ZIAEYEqdhpEw0fhCbkKa68dxyNtsfNzzpnZu3NhwpYGBdUqcA+4A1wEZiK0DawD74FWSml3JAJ1CngGLAIngU1gFfgZKWeAG8AFoAu8At6mlH6VtqTOqJ/UP2pDnRuQO6c27VlbrQ0Dvq121Fulag7q5qPmW18SdSqUd9Qrw4Jn9bNR21YrRQkvYixDKy/AuB3jWjocqKpdtXFU8AxrOTqZzp2PgvnaMRDUA+tB7mypG+OCZ3hbahPgRPguAR9LihaicEu9WcKxClzOi/fU1wPAk7rjgX0uEfNG3cs7mJjtE+wA5/olpZQEHgNf6K2NJyW4NeD7v7c4WptjSc0svlMjdzyM2fbdOyOA7x/T+7mzGj9H8xgIWuquevpw4HmsivkxwBdC/WJRsBKLqqPOHgH8aqybtcJlF0m1WLndUToJ5V31q9r3NOYk7Wh1Wa0PyK3HzA3l/4H3uzIrwFNgCThF7/x/AH5EylngOnAe6AAvgXcppd9DEWRE08DdeIou/RVgJaXUGYQzUfsL+zmwV7BtIq0AAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "List supported issue types for repository owner (organization).",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "owner": {
+              "type": "string",
+              "description": "The organization owner of the repository"
+            }
+          },
+          "required": [
+            "owner"
+          ]
+        },
+        "annotations": {
+          "title": "List available issue types",
+          "readOnlyHint": true
+        }
+      },
+      {
+        "name": "list_issues",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAC2UlEQVRIicWVMUyTaRjHf/+vVUpOJOdilOYoUvVreq2CDmLOwdlAS5xMbrrhBifjYG7QjYuJw108nZx1huLgYlw0QshxChUK2koxHHcuCmgsFfieG0or3kGPSoz/8X3f5/97nvfN8z7wmaVqm9FodFfR/EnMugy5giCAwYwgI9Ff9Hl9L9Lp1zUBgsGO+rqGwnlhF4CdwBSyAUwvS1G220zHBSFgHtmVxYWvfp2ZGSj8LyAcjgfZphTQZtAr7OdsZvSP9RIJR+LtQhcNusF+d1aUfPp05M8NAavmg8AOk3cmN56+s1Hpa7U/cviUYbcw3jgex9ZCKoBgsKM+0PDuAdBq2He5zOiTzZiXtc+NxRw598GeLRcWTuTz+UUAp3ygrqFwHmgzeWdqNQd4PpFOy/gedNQfaDz3UQXRaHRX0fNPGdzNZUZO12q+VuHIoV7g5Hu/1/IinX7tABTNnwR2SvRsxRzAzOsBGuuWfAkoX5FZFzCVHR95tFVAbiI9DEwj6wLwl5YVMTRYLTDsxjuRrgGYYz/kxkbvbXRWMOBB24cKYI9ks1X8hXQDaAaa5XG9WjImZgV71wI+m8qAv8y0t1pSmP0ITANTmHO2qqvRZDALlTdgHKyjWkx2YvQ2cHtTacMxYBhWK5DoF4TCkXj7Jg02VKsbOwI0Y+qvALZrOQXMC13cKkDSJWBuJUCqAhgbG3uF7IpBcn/k8KlPNQ+78U5QQuhy/vHjuQoAYPndwi9gw4bd2ufGYrWatxz8No50ExhaKsz9Vl6vAPL5/KKzoiTGG0fOg1oqCbvxTp/juw/M+zynu/yTwjoD58CBQ02ez/pAR4E+M69ntf3/o1Y3dqR050oAQz7P6Z6cfPRRw647MkOhUMAfaDyH+AloBKYNPRT292rQHoMOSp09J3TZlt5ezWazxX97VR3638RiX9ct+RImSyBcrDT0ETMyMp4ptRIgVX7QL6J/ALSUEwJ5rdg2AAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABxElEQVRIibWVvW4TURCFv0vlNEDcIHAkKAERJOIKSjoUArwBPwUFFaKIIngAJARCPIgdh4cgRBYt6ZIAEYEqdhpEw0fhCbkKa68dxyNtsfNzzpnZu3NhwpYGBdUqcA+4A1wEZiK0DawD74FWSml3JAJ1CngGLAIngU1gFfgZKWeAG8AFoAu8At6mlH6VtqTOqJ/UP2pDnRuQO6c27VlbrQ0Dvq121Fulag7q5qPmW18SdSqUd9Qrw4Jn9bNR21YrRQkvYixDKy/AuB3jWjocqKpdtXFU8AxrOTqZzp2PgvnaMRDUA+tB7mypG+OCZ3hbahPgRPguAR9LihaicEu9WcKxClzOi/fU1wPAk7rjgX0uEfNG3cs7mJjtE+wA5/olpZQEHgNf6K2NJyW4NeD7v7c4WptjSc0svlMjdzyM2fbdOyOA7x/T+7mzGj9H8xgIWuquevpw4HmsivkxwBdC/WJRsBKLqqPOHgH8aqybtcJlF0m1WLndUToJ5V31q9r3NOYk7Wh1Wa0PyK3HzA3l/4H3uzIrwFNgCThF7/x/AH5EylngOnAe6AAvgXcppd9DEWRE08DdeIou/RVgJaXUGYQzUfsL+zmwV7BtIq0AAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "List issues in a GitHub repository. For pagination, use the 'endCursor' from the previous response's 'pageInfo' in the 'after' parameter.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "after": {
+              "type": "string",
+              "description": "Cursor for pagination. Use the endCursor from the previous page's PageInfo for GraphQL APIs."
+            },
+            "direction": {
+              "type": "string",
+              "description": "Order direction. If provided, the 'orderBy' also needs to be provided.",
+              "enum": [
+                "ASC",
+                "DESC"
+              ]
+            },
+            "labels": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Filter by labels"
+            },
+            "orderBy": {
+              "type": "string",
+              "description": "Order issues by field. If provided, the 'direction' also needs to be provided.",
+              "enum": [
+                "CREATED_AT",
+                "UPDATED_AT",
+                "COMMENTS"
+              ]
+            },
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "perPage": {
+              "type": "number",
+              "description": "Results per page for pagination (min 1, max 100)",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            },
+            "since": {
+              "type": "string",
+              "description": "Filter by date (ISO 8601 timestamp)"
+            },
+            "state": {
+              "type": "string",
+              "description": "Filter by state, by default both open and closed issues are returned when not provided",
+              "enum": [
+                "OPEN",
+                "CLOSED"
+              ]
+            }
+          },
+          "required": [
+            "owner",
+            "repo"
+          ]
+        },
+        "annotations": {
+          "title": "List issues",
+          "readOnlyHint": true
+        }
+      },
+      {
+        "name": "list_pull_requests",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACwUlEQVRIie2Vz28UZRjHP993pi0QIC3YahNjirtmd3bS3Q1eUHvQEPUiEv8A4kXjwRJ78MCFBLjBBRKCHowHE38cNCbGGx6IUoKiodtNpoNmTJp4oSJNQ3pw29l5POxus2wo3QTwxPc0887zfD7zvu9kXnjEUfdNrjj5vJOmMP4e9JrfR1G02tuQD8tvgpck0dxCPwK30ViqnJTcr4bOmfRlI/PrhUJ5313woDpDpu8ss7f6nYHrvDnGcYlPsoY/bKaXwHY3HWfvgmNnMX0zvMM7069A3c3pkEYWa7UVgFxQPSfs7SSeH3k2rEy5jMubMBoG1yQ+SBbm53of+gCybMkk/H8VAFdbZisZLAFsJ11oyL+BUURcwrjWAZixXeIwxs/5UuVAr0QAYRjubGR+HWy3mb6QCIBXQe8nce0jgIkwfMo3/xLG085x8I9ofkMyUa0O+w2rgS0mcf3lboEDiKJo1cvsIDDr4D1DhTb8407hYhTdTJW+AvrdMnuhG9Je1m9BBzbfjXbyQcXypeqJLQt7+0rVE/mgYr3j7l7FDzOPBY8FDx6vc1EolPeNjI5/Jpgw7Lm9o+Pry//c/K0PhnLFyrSMDxE79jwxvn9079gvt28vrUD7V1EoFHalbltd2C7DfS4sAF4DTSdx7cL96LliZVriPPADuL+geRh0Z8il5SiKVn2ATENvCCYw78U/b8xdBcgHlYuGHQXuK5A4ClxM4vnXW8Lqp5JdWWt6h4CvWnsgxgDSbRZ3Gg0tCJ7sY4nGwDZOt/WBZtzN9FswLgM2sGann5mcPDaw5pWEHQH7cUu86SdkR3LF6tfrA814MNVpwNrM1leUxPXrSKfMeHcwdctyNotY8c3NbMX3LJsB3ZHsymDqlkHvYHYyievXWxPpSj4o75eYIuPWZof+vRKG4c61pncIx6gZsx34/5L/ACy3ElqUYhuvAAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABn0lEQVRIie2Vvy5EURDGvyMUkhUU/pS2Q2clwvIKqL0Cm9ArrBcQShJPoLFR2YaIhIjQ7a7E39IiCgqVn8KsPY697E3oTHPumTPf990z986M9Mfm/A0wKGlMUlnSlnPuOQQAE5LOnXOFWErAIvBK1S6BZBAzZ2fzcckHjXwVaAXSwD2wWYN8A2iKK1ABt3m+ZeDRnseIthdgDxioxd1o662tfZIO7Lnf8xcklST1StqRdORxNEualHQIDDvnTmvdIGE5vwdWgLy93bQX0w0UgSdgKMC3AdfA7ndpSgKbduUbYBoI/7Ju4BiYrYFfAl4iBbxAgOyPgV9xWYDQ3xCXKK79C/wL/KJZoeW8QpsJCy0C54AMULaGmQu7sIAW4MpaxTKwbQU3U4dAxmLzwLpxXAIJP2jKgkY8Xx4o1SFwBmx7+7RxTUnVb9Bpa9HDFiR1/SRgWH+6FT3/h2qK6sBpB0aBB7yB880NcpaWtGHXjCsVBmb5PDIvgJ46BJKW84q9AguV87Adp/Q+9O8UMfQjRBKSxiV1SNp3zp3Ug/sVewPruexhKwhGXQAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "List pull requests in a GitHub repository. If the user specifies an author, then DO NOT use this tool and use the search_pull_requests tool instead.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "base": {
+              "type": "string",
+              "description": "Filter by base branch"
+            },
+            "direction": {
+              "type": "string",
+              "description": "Sort direction",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            },
+            "head": {
+              "type": "string",
+              "description": "Filter by head user/org and branch"
+            },
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "page": {
+              "type": "number",
+              "description": "Page number for pagination (min 1)",
+              "minimum": 1
+            },
+            "perPage": {
+              "type": "number",
+              "description": "Results per page for pagination (min 1, max 100)",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            },
+            "sort": {
+              "type": "string",
+              "description": "Sort by",
+              "enum": [
+                "created",
+                "updated",
+                "popularity",
+                "long-running"
+              ]
+            },
+            "state": {
+              "type": "string",
+              "description": "Filter by state",
+              "enum": [
+                "open",
+                "closed",
+                "all"
+              ]
+            }
+          },
+          "required": [
+            "owner",
+            "repo"
+          ]
+        },
+        "annotations": {
+          "title": "List pull requests",
+          "readOnlyHint": true
+        }
+      },
+      {
+        "name": "list_releases",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "List releases in a GitHub repository",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "page": {
+              "type": "number",
+              "description": "Page number for pagination (min 1)",
+              "minimum": 1
+            },
+            "perPage": {
+              "type": "number",
+              "description": "Results per page for pagination (min 1, max 100)",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            }
+          },
+          "required": [
+            "owner",
+            "repo"
+          ]
+        },
+        "annotations": {
+          "title": "List releases",
+          "readOnlyHint": true
+        }
+      },
+      {
+        "name": "list_tags",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "List git tags in a GitHub repository",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "page": {
+              "type": "number",
+              "description": "Page number for pagination (min 1)",
+              "minimum": 1
+            },
+            "perPage": {
+              "type": "number",
+              "description": "Results per page for pagination (min 1, max 100)",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            }
+          },
+          "required": [
+            "owner",
+            "repo"
+          ]
+        },
+        "annotations": {
+          "title": "List tags",
+          "readOnlyHint": true
+        }
+      },
+      {
+        "name": "merge_pull_request",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACeElEQVRIibWVTUhUYRSGn/e74+iiQih1F9Vcmj9sptylUVBYkO4jcNeuJBdFKxe1CYQokGrRKjCEdtmqwEVmtqomQWeiUdc2EBUtUufe0yLHn1KLGXtX5zvn4zz3vd8f/Gfp90Qs0drmpA6MT1EveDo1NfV92wB+KnMdo39Nfs4L7eSHD5Nz1QJcJYglWtsw+iUehAuRRjO1g+0KHLerbb4OIHnHAC1FdW129s3XmUJuwnBDoOPbA7BwHsD7QWq1HKYN5msBRCpB1AueLoSROSkciSUyj5ClhE6BLtYC8CpBqVRabNrdMmIiJdQjuUbQ1WI+d78WwIbykxnzU9np7ejlNq2YxQ4ebNtTKyCyWcEgYl55EDj/a7ihFEtkLkr0As2YxjwL+9aem00dCEYNzvnJzLDvH27aaM5y80HEnKGHKGwPnEbT6fSOvzpAmrDQnkncpC7siiUzz2QqIPu25iOuGBorTufO/AJmH0v2ajHwuoHhrQHATOH9rQPJ7IjDLgs6kZ0F6it1AzArVcZLdUE+WnYgmv/uYFmz+dxH4NJGNT+RfYLCE7F4tn0pGkxHy94AmBm8/GfAVvIs7AukUTkbj5YdYIbZ9WJh8m1lzrrbNB4/tD+QuyPsdCibF26gmM/dY/NdRDqd3rEYeN04mswYL+ZXm68DxOPxnWXXMClsp+GGhCWBTtClYj53t1qXK78oVH2XYB/mHZ0pvHsN4Cczzw3rBaoGrJ6D5ZUvN1i+kjI0LWiptjmscbC88hZZCAf2trZeq1v0UsJ6wF7UAlhxUMxPvkW6AboQLbvPcjaO+BIx11cL4I9H308eOiLRQUhpOx79/66fNKzrOCYNDm0AAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABjElEQVRIibWVPS/DURTGnysSC0HiZdWVrZ28JDaLT8BHaBsMdjqZJDXiAzC2LF5mX6GtATGiIsGARH+Gnj9X8a/kf3uWe3Py3Oc559xz75E6bK7VAWQkzUi6lXTonHsOpgYUgAZfdgmkQpFnjHwb6AemgDpQCiWwYlEPeL4i8JCEt8vb39g67vkmPH8yA3qt5nVgCzi1jLJBBEwkBZSAdxPKAj86LYQQQCU4cYvAKzDUSYF3YC+uRIAD8sA58ACU//VuTODE1n1g+A9c3jBH1tJ1a5TeCPNrdACSCpKeJG1IepN0LKkm6dGDrkqqOOdm7dyUpDNJi865PUnqjsvEObcJHEhaljQnaV5STwvszttXbR2J441KtB4LauLKVpZpYBDYte8mHUogZTWPrAGstTtQBl6AayDX7qHZD7AALMVGDvQBV5ZyETi2qHLtMvmXWRQAk57vBKgl4fV/0+jmq56vImk0icCnAWm7pB3riGngnlADx0TW+T4yL4CxJJy/Df20mkP/TqGHfifsA7INs3X5i3+yAAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Merge a pull request in a GitHub repository.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "commit_message": {
+              "type": "string",
+              "description": "Extra detail for merge commit"
+            },
+            "commit_title": {
+              "type": "string",
+              "description": "Title for merge commit"
+            },
+            "merge_method": {
+              "type": "string",
+              "description": "Merge method",
+              "enum": [
+                "merge",
+                "squash",
+                "rebase"
+              ]
+            },
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "pullNumber": {
+              "type": "number",
+              "description": "Pull request number"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            }
+          },
+          "required": [
+            "owner",
+            "repo",
+            "pullNumber"
+          ]
+        },
+        "annotations": {
+          "title": "Merge pull request"
+        }
+      },
+      {
+        "name": "pull_request_read",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACwUlEQVRIie2Vz28UZRjHP993pi0QIC3YahNjirtmd3bS3Q1eUHvQEPUiEv8A4kXjwRJ78MCFBLjBBRKCHowHE38cNCbGGx6IUoKiodtNpoNmTJp4oSJNQ3pw29l5POxus2wo3QTwxPc0887zfD7zvu9kXnjEUfdNrjj5vJOmMP4e9JrfR1G02tuQD8tvgpck0dxCPwK30ViqnJTcr4bOmfRlI/PrhUJ5313woDpDpu8ss7f6nYHrvDnGcYlPsoY/bKaXwHY3HWfvgmNnMX0zvMM7069A3c3pkEYWa7UVgFxQPSfs7SSeH3k2rEy5jMubMBoG1yQ+SBbm53of+gCybMkk/H8VAFdbZisZLAFsJ11oyL+BUURcwrjWAZixXeIwxs/5UuVAr0QAYRjubGR+HWy3mb6QCIBXQe8nce0jgIkwfMo3/xLG085x8I9ofkMyUa0O+w2rgS0mcf3lboEDiKJo1cvsIDDr4D1DhTb8407hYhTdTJW+AvrdMnuhG9Je1m9BBzbfjXbyQcXypeqJLQt7+0rVE/mgYr3j7l7FDzOPBY8FDx6vc1EolPeNjI5/Jpgw7Lm9o+Pry//c/K0PhnLFyrSMDxE79jwxvn9079gvt28vrUD7V1EoFHalbltd2C7DfS4sAF4DTSdx7cL96LliZVriPPADuL+geRh0Z8il5SiKVn2ATENvCCYw78U/b8xdBcgHlYuGHQXuK5A4ClxM4vnXW8Lqp5JdWWt6h4CvWnsgxgDSbRZ3Gg0tCJ7sY4nGwDZOt/WBZtzN9FswLgM2sGann5mcPDaw5pWEHQH7cUu86SdkR3LF6tfrA814MNVpwNrM1leUxPXrSKfMeHcwdctyNotY8c3NbMX3LJsB3ZHsymDqlkHvYHYyievXWxPpSj4o75eYIuPWZof+vRKG4c61pncIx6gZsx34/5L/ACy3ElqUYhuvAAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABn0lEQVRIie2Vvy5EURDGvyMUkhUU/pS2Q2clwvIKqL0Cm9ArrBcQShJPoLFR2YaIhIjQ7a7E39IiCgqVn8KsPY697E3oTHPumTPf990z986M9Mfm/A0wKGlMUlnSlnPuOQQAE5LOnXOFWErAIvBK1S6BZBAzZ2fzcckHjXwVaAXSwD2wWYN8A2iKK1ABt3m+ZeDRnseIthdgDxioxd1o662tfZIO7Lnf8xcklST1StqRdORxNEualHQIDDvnTmvdIGE5vwdWgLy93bQX0w0UgSdgKMC3AdfA7ndpSgKbduUbYBoI/7Ju4BiYrYFfAl4iBbxAgOyPgV9xWYDQ3xCXKK79C/wL/KJZoeW8QpsJCy0C54AMULaGmQu7sIAW4MpaxTKwbQU3U4dAxmLzwLpxXAIJP2jKgkY8Xx4o1SFwBmx7+7RxTUnVb9Bpa9HDFiR1/SRgWH+6FT3/h2qK6sBpB0aBB7yB880NcpaWtGHXjCsVBmb5PDIvgJ46BJKW84q9AguV87Adp/Q+9O8UMfQjRBKSxiV1SNp3zp3Ug/sVewPruexhKwhGXQAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Get information on a specific pull request in GitHub repository.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "method": {
+              "type": "string",
+              "description": "Action to specify what pull request data needs to be retrieved from GitHub. \nPossible options: \n 1. get - Get details of a specific pull request.\n 2. get_diff - Get the diff of a pull request.\n 3. get_status - Get combined commit status of a head commit in a pull request.\n 4. get_files - Get the list of files changed in a pull request. Use with pagination parameters to control the number of results returned.\n 5. get_review_comments - Get review threads on a pull request. Each thread contains logically grouped review comments made on the same code location during pull request reviews. Returns threads with metadata (isResolved, isOutdated, isCollapsed) and their associated comments. Use cursor-based pagination (perPage, after) to control results.\n 6. get_reviews - Get the reviews on a pull request. When asked for review comments, use get_review_comments method.\n 7. get_comments - Get comments on a pull request. Use this if user doesn't specifically want review comments. Use with pagination parameters to control the number of results returned.\n 8. get_check_runs - Get check runs for the head commit of a pull request. Check runs are the individual CI/CD jobs and checks that run on the PR.\n",
+              "enum": [
+                "get",
+                "get_diff",
+                "get_status",
+                "get_files",
+                "get_review_comments",
+                "get_reviews",
+                "get_comments",
+                "get_check_runs"
+              ]
+            },
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "page": {
+              "type": "number",
+              "description": "Page number for pagination (min 1)",
+              "minimum": 1
+            },
+            "perPage": {
+              "type": "number",
+              "description": "Results per page for pagination (min 1, max 100)",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "pullNumber": {
+              "type": "number",
+              "description": "Pull request number"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            }
+          },
+          "required": [
+            "method",
+            "owner",
+            "repo",
+            "pullNumber"
+          ]
+        },
+        "annotations": {
+          "title": "Get details for a single pull request",
+          "readOnlyHint": true
+        }
+      },
+      {
+        "name": "pull_request_review_write",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACwUlEQVRIie2Vz28UZRjHP993pi0QIC3YahNjirtmd3bS3Q1eUHvQEPUiEv8A4kXjwRJ78MCFBLjBBRKCHowHE38cNCbGGx6IUoKiodtNpoNmTJp4oSJNQ3pw29l5POxus2wo3QTwxPc0887zfD7zvu9kXnjEUfdNrjj5vJOmMP4e9JrfR1G02tuQD8tvgpck0dxCPwK30ViqnJTcr4bOmfRlI/PrhUJ5313woDpDpu8ss7f6nYHrvDnGcYlPsoY/bKaXwHY3HWfvgmNnMX0zvMM7069A3c3pkEYWa7UVgFxQPSfs7SSeH3k2rEy5jMubMBoG1yQ+SBbm53of+gCybMkk/H8VAFdbZisZLAFsJ11oyL+BUURcwrjWAZixXeIwxs/5UuVAr0QAYRjubGR+HWy3mb6QCIBXQe8nce0jgIkwfMo3/xLG085x8I9ofkMyUa0O+w2rgS0mcf3lboEDiKJo1cvsIDDr4D1DhTb8407hYhTdTJW+AvrdMnuhG9Je1m9BBzbfjXbyQcXypeqJLQt7+0rVE/mgYr3j7l7FDzOPBY8FDx6vc1EolPeNjI5/Jpgw7Lm9o+Pry//c/K0PhnLFyrSMDxE79jwxvn9079gvt28vrUD7V1EoFHalbltd2C7DfS4sAF4DTSdx7cL96LliZVriPPADuL+geRh0Z8il5SiKVn2ATENvCCYw78U/b8xdBcgHlYuGHQXuK5A4ClxM4vnXW8Lqp5JdWWt6h4CvWnsgxgDSbRZ3Gg0tCJ7sY4nGwDZOt/WBZtzN9FswLgM2sGann5mcPDaw5pWEHQH7cUu86SdkR3LF6tfrA814MNVpwNrM1leUxPXrSKfMeHcwdctyNotY8c3NbMX3LJsB3ZHsymDqlkHvYHYyievXWxPpSj4o75eYIuPWZof+vRKG4c61pncIx6gZsx34/5L/ACy3ElqUYhuvAAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABn0lEQVRIie2Vvy5EURDGvyMUkhUU/pS2Q2clwvIKqL0Cm9ArrBcQShJPoLFR2YaIhIjQ7a7E39IiCgqVn8KsPY697E3oTHPumTPf990z986M9Mfm/A0wKGlMUlnSlnPuOQQAE5LOnXOFWErAIvBK1S6BZBAzZ2fzcckHjXwVaAXSwD2wWYN8A2iKK1ABt3m+ZeDRnseIthdgDxioxd1o662tfZIO7Lnf8xcklST1StqRdORxNEualHQIDDvnTmvdIGE5vwdWgLy93bQX0w0UgSdgKMC3AdfA7ndpSgKbduUbYBoI/7Ju4BiYrYFfAl4iBbxAgOyPgV9xWYDQ3xCXKK79C/wL/KJZoeW8QpsJCy0C54AMULaGmQu7sIAW4MpaxTKwbQU3U4dAxmLzwLpxXAIJP2jKgkY8Xx4o1SFwBmx7+7RxTUnVb9Bpa9HDFiR1/SRgWH+6FT3/h2qK6sBpB0aBB7yB880NcpaWtGHXjCsVBmb5PDIvgJ46BJKW84q9AguV87Adp/Q+9O8UMfQjRBKSxiV1SNp3zp3Ug/sVewPruexhKwhGXQAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Create and/or submit, delete review of a pull request.\n\nAvailable methods:\n- create: Create a new review of a pull request. If \"event\" parameter is provided, the review is submitted. If \"event\" is omitted, a pending review is created.\n- submit_pending: Submit an existing pending review of a pull request. This requires that a pending review exists for the current user on the specified pull request. The \"body\" and \"event\" parameters are used when submitting the review.\n- delete_pending: Delete an existing pending review of a pull request. This requires that a pending review exists for the current user on the specified pull request.\n",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "body": {
+              "type": "string",
+              "description": "Review comment text"
+            },
+            "commitID": {
+              "type": "string",
+              "description": "SHA of commit to review"
+            },
+            "event": {
+              "type": "string",
+              "description": "Review action to perform.",
+              "enum": [
+                "APPROVE",
+                "REQUEST_CHANGES",
+                "COMMENT"
+              ]
+            },
+            "method": {
+              "type": "string",
+              "description": "The write operation to perform on pull request review.",
+              "enum": [
+                "create",
+                "submit_pending",
+                "delete_pending"
+              ]
+            },
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "pullNumber": {
+              "type": "number",
+              "description": "Pull request number"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            }
+          },
+          "required": [
+            "method",
+            "owner",
+            "repo",
+            "pullNumber"
+          ]
+        },
+        "annotations": {
+          "title": "Write operations (create, submit, delete) on pull request reviews."
+        }
+      },
+      {
+        "name": "push_files",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Push multiple files to a GitHub repository in a single commit",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "branch": {
+              "type": "string",
+              "description": "Branch to push to"
+            },
+            "files": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "content": {
+                    "type": "string",
+                    "description": "file content"
+                  },
+                  "path": {
+                    "type": "string",
+                    "description": "path to the file"
+                  }
+                },
+                "required": [
+                  "path",
+                  "content"
+                ]
+              },
+              "description": "Array of file objects to push, each object with path (string) and content (string)"
+            },
+            "message": {
+              "type": "string",
+              "description": "Commit message"
+            },
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            }
+          },
+          "required": [
+            "owner",
+            "repo",
+            "branch",
+            "files",
+            "message"
+          ]
+        },
+        "annotations": {
+          "title": "Push files to repository"
+        }
+      },
+      {
+        "name": "request_copilot_review",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAC20lEQVRIidWUS4wMURSGv3O7kWmPEMRrSMzcbl1dpqtmGuOxsCKECCKxEBusSJhIWEhsWLFAbC1sWFiISBARCyQ2kzSZGaMxHokgXvGIiMH0PRZjpJqqHpb+TeX+59z//H/q5sD/DqlX9H1/zFeX2qzIKoFWYDKgwBtUymL0UkNaT3V3d3/+5wG2EGxB9TDIxGFMvhVhb9/drpN/NaDJC7MGdwJk6TDCv0Gvq0lve9R762GUNdFDLleaZNBrICGq+4yhvf9TJtP/KZNB2PrLlbBliBfRhajuAwnFVa/n8/nkxFkv3GO9oJrzgwVxdesV71ov6I2r5fxggfWCatYL9yYmUJgLPH7Q29WZ4OED6Me4wuAdeQK6MMqna9t0GuibBHFAmgZ9JMG9BhkXZWoSCDSATIq7aguBD0wBplq/tZBgYDIwKnZAs99mFRYD9vd/YK0dpcqhobM6d9haWyOULRTbAauwuNlvsxHTYP3iBnVyXGAa8BIYC3oVeAKioCtAPEE7FCOgR0ErIJdBBZgNskzh40+NF6K6s+9e91lp9osrxMnFoTSmSmPVsF+E5cB0YEDgtoMjjypd5wCy+WC9GnajhEAa4bkqV9LOHKwa9/yneYeyUqwX3AdyQ5EeVrrqro/hYL0g+ggemKh4HGbPmVu0+fB8U76lpR6XgJwZpoGUpNYiusZg1tXjkmCAav0OMTXfJC4eVYPqwbot6l4BCPqyLhd7lwMAWC/cYb3gi/UCzRaKOxsbFzVEM1iv2Ebt5v2Dm14qZbJecZf1Ah3UCrcTbbB+awHnjgHLgHeinHYqZ8aPSXWWy+XvcQZLpdKI9/0D7UbZiLIJmABckVSqo+/OrUrNgF+D8q1LEdcBrAJGAJ8ROlGeicorABWdAswE5gOjge8CF8Ad66v03IjqJb75WS0tE0YOmNWqLBGReaAzgIkMLrt3oM9UpSzCzW9pd+FpT8/7JK3/Gz8Ao5X6wtwP7N4AAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACCElEQVRIid2UPWsUYRSFn3dxWWJUkESiBgslFokfhehGiGClBBQx4h9IGlEh2ijYxh+gxEL/hIWwhYpF8KNZsFRJYdJEiUbjCkqisj4W+y6Mk5nd1U4PDMOce+45L3fmDvzXUDeo59WK+kb9rn5TF9R76jm1+2/NJ9QPtseSOv4nxrvVmQ6M05hRB9qZ98ZR1NRralntitdEwmw8wQ9HbS329rQKuKLW1XJO/aX6IqdWjr1Xk/y6lG4vMBdCqOacoZZ3uBBCVZ0HDrcK2AYs5ZkAuwBb1N8Dm5JEISXoAnqzOtU9QB+wVR3KCdgClDIr6kCc4c/0O1BLNnahiYpaSmmGY62e/JpCLJ4FpmmMaBHYCDwC5mmMZBQYBC7HnhvAK+B+fN4JHAM+R4+3wGQI4S7qaExtol+9o86pq+oX9Yk6ljjtGfVprK2qr9Xb6vaET109jjqb3Jac2XaM1PLNpok1Aep+G/+dfa24nADTX1EWTgOngLE2XCYKQL0DTfKex2WhXgCutxG9i/fFNlwWpgBQL6orcWyTaldToRbUA2pow61XL0WPFfXCb1HqkPowCj6q0+qIWsw7nlpUj6i31OXY+0AdbGpCRtNRGgt1AigCX4EqsJAYTR+wAzgEdAM/gApwM4TwOOm3JiARtBk4CYwAB4F+oIfGZi/HwOfAM6ASQviU5/Vv4xcBzmW2eT1nrQAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Request a GitHub Copilot code review for a pull request. Use this for automated feedback on pull requests, usually before requesting a human reviewer.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "pullNumber": {
+              "type": "number",
+              "description": "Pull request number"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            }
+          },
+          "required": [
+            "owner",
+            "repo",
+            "pullNumber"
+          ]
+        },
+        "annotations": {
+          "title": "Request Copilot review"
+        }
+      },
+      {
+        "name": "search_code",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Fast and precise code search across ALL GitHub repositories using GitHub's native search engine. Best for finding exact symbols, functions, classes, or specific code patterns.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "order": {
+              "type": "string",
+              "description": "Sort order for results",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            },
+            "page": {
+              "type": "number",
+              "description": "Page number for pagination (min 1)",
+              "minimum": 1
+            },
+            "perPage": {
+              "type": "number",
+              "description": "Results per page for pagination (min 1, max 100)",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "query": {
+              "type": "string",
+              "description": "Search query using GitHub's powerful code search syntax. Examples: 'content:Skill language:Java org:github', 'NOT is:archived language:Python OR language:go', 'repo:github/github-mcp-server'. Supports exact matching, language filters, path filters, and more."
+            },
+            "sort": {
+              "type": "string",
+              "description": "Sort field ('indexed' only)"
+            }
+          },
+          "required": [
+            "query"
+          ]
+        },
+        "annotations": {
+          "title": "Search code",
+          "readOnlyHint": true
+        }
+      },
+      {
+        "name": "search_issues",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAC2UlEQVRIicWVMUyTaRjHf/+vVUpOJOdilOYoUvVreq2CDmLOwdlAS5xMbrrhBifjYG7QjYuJw108nZx1huLgYlw0QshxChUK2koxHHcuCmgsFfieG0or3kGPSoz/8X3f5/97nvfN8z7wmaVqm9FodFfR/EnMugy5giCAwYwgI9Ff9Hl9L9Lp1zUBgsGO+rqGwnlhF4CdwBSyAUwvS1G220zHBSFgHtmVxYWvfp2ZGSj8LyAcjgfZphTQZtAr7OdsZvSP9RIJR+LtQhcNusF+d1aUfPp05M8NAavmg8AOk3cmN56+s1Hpa7U/cviUYbcw3jgex9ZCKoBgsKM+0PDuAdBq2He5zOiTzZiXtc+NxRw598GeLRcWTuTz+UUAp3ygrqFwHmgzeWdqNQd4PpFOy/gedNQfaDz3UQXRaHRX0fNPGdzNZUZO12q+VuHIoV7g5Hu/1/IinX7tABTNnwR2SvRsxRzAzOsBGuuWfAkoX5FZFzCVHR95tFVAbiI9DEwj6wLwl5YVMTRYLTDsxjuRrgGYYz/kxkbvbXRWMOBB24cKYI9ks1X8hXQDaAaa5XG9WjImZgV71wI+m8qAv8y0t1pSmP0ITANTmHO2qqvRZDALlTdgHKyjWkx2YvQ2cHtTacMxYBhWK5DoF4TCkXj7Jg02VKsbOwI0Y+qvALZrOQXMC13cKkDSJWBuJUCqAhgbG3uF7IpBcn/k8KlPNQ+78U5QQuhy/vHjuQoAYPndwi9gw4bd2ufGYrWatxz8No50ExhaKsz9Vl6vAPL5/KKzoiTGG0fOg1oqCbvxTp/juw/M+zynu/yTwjoD58CBQ02ez/pAR4E+M69ntf3/o1Y3dqR050oAQz7P6Z6cfPRRw647MkOhUMAfaDyH+AloBKYNPRT292rQHoMOSp09J3TZlt5ezWazxX97VR3638RiX9ct+RImSyBcrDT0ETMyMp4ptRIgVX7QL6J/ALSUEwJ5rdg2AAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABxElEQVRIibWVvW4TURCFv0vlNEDcIHAkKAERJOIKSjoUArwBPwUFFaKIIngAJARCPIgdh4cgRBYt6ZIAEYEqdhpEw0fhCbkKa68dxyNtsfNzzpnZu3NhwpYGBdUqcA+4A1wEZiK0DawD74FWSml3JAJ1CngGLAIngU1gFfgZKWeAG8AFoAu8At6mlH6VtqTOqJ/UP2pDnRuQO6c27VlbrQ0Dvq121Fulag7q5qPmW18SdSqUd9Qrw4Jn9bNR21YrRQkvYixDKy/AuB3jWjocqKpdtXFU8AxrOTqZzp2PgvnaMRDUA+tB7mypG+OCZ3hbahPgRPguAR9LihaicEu9WcKxClzOi/fU1wPAk7rjgX0uEfNG3cs7mJjtE+wA5/olpZQEHgNf6K2NJyW4NeD7v7c4WptjSc0svlMjdzyM2fbdOyOA7x/T+7mzGj9H8xgIWuquevpw4HmsivkxwBdC/WJRsBKLqqPOHgH8aqybtcJlF0m1WLndUToJ5V31q9r3NOYk7Wh1Wa0PyK3HzA3l/4H3uzIrwFNgCThF7/x/AH5EylngOnAe6AAvgXcppd9DEWRE08DdeIou/RVgJaXUGYQzUfsL+zmwV7BtIq0AAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Search for issues in GitHub repositories using issues search syntax already scoped to is:issue",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "order": {
+              "type": "string",
+              "description": "Sort order",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            },
+            "owner": {
+              "type": "string",
+              "description": "Optional repository owner. If provided with repo, only issues for this repository are listed."
+            },
+            "page": {
+              "type": "number",
+              "description": "Page number for pagination (min 1)",
+              "minimum": 1
+            },
+            "perPage": {
+              "type": "number",
+              "description": "Results per page for pagination (min 1, max 100)",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "query": {
+              "type": "string",
+              "description": "Search query using GitHub issues search syntax"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Optional repository name. If provided with owner, only issues for this repository are listed."
+            },
+            "sort": {
+              "type": "string",
+              "description": "Sort field by number of matches of categories, defaults to best match",
+              "enum": [
+                "comments",
+                "reactions",
+                "reactions-+1",
+                "reactions--1",
+                "reactions-smile",
+                "reactions-thinking_face",
+                "reactions-heart",
+                "reactions-tada",
+                "interactions",
+                "created",
+                "updated"
+              ]
+            }
+          },
+          "required": [
+            "query"
+          ]
+        },
+        "annotations": {
+          "title": "Search issues",
+          "readOnlyHint": true
+        }
+      },
+      {
+        "name": "search_pull_requests",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACwUlEQVRIie2Vz28UZRjHP993pi0QIC3YahNjirtmd3bS3Q1eUHvQEPUiEv8A4kXjwRJ78MCFBLjBBRKCHowHE38cNCbGGx6IUoKiodtNpoNmTJp4oSJNQ3pw29l5POxus2wo3QTwxPc0887zfD7zvu9kXnjEUfdNrjj5vJOmMP4e9JrfR1G02tuQD8tvgpck0dxCPwK30ViqnJTcr4bOmfRlI/PrhUJ5313woDpDpu8ss7f6nYHrvDnGcYlPsoY/bKaXwHY3HWfvgmNnMX0zvMM7069A3c3pkEYWa7UVgFxQPSfs7SSeH3k2rEy5jMubMBoG1yQ+SBbm53of+gCybMkk/H8VAFdbZisZLAFsJ11oyL+BUURcwrjWAZixXeIwxs/5UuVAr0QAYRjubGR+HWy3mb6QCIBXQe8nce0jgIkwfMo3/xLG085x8I9ofkMyUa0O+w2rgS0mcf3lboEDiKJo1cvsIDDr4D1DhTb8407hYhTdTJW+AvrdMnuhG9Je1m9BBzbfjXbyQcXypeqJLQt7+0rVE/mgYr3j7l7FDzOPBY8FDx6vc1EolPeNjI5/Jpgw7Lm9o+Pry//c/K0PhnLFyrSMDxE79jwxvn9079gvt28vrUD7V1EoFHalbltd2C7DfS4sAF4DTSdx7cL96LliZVriPPADuL+geRh0Z8il5SiKVn2ATENvCCYw78U/b8xdBcgHlYuGHQXuK5A4ClxM4vnXW8Lqp5JdWWt6h4CvWnsgxgDSbRZ3Gg0tCJ7sY4nGwDZOt/WBZtzN9FswLgM2sGann5mcPDaw5pWEHQH7cUu86SdkR3LF6tfrA814MNVpwNrM1leUxPXrSKfMeHcwdctyNotY8c3NbMX3LJsB3ZHsymDqlkHvYHYyievXWxPpSj4o75eYIuPWZof+vRKG4c61pncIx6gZsx34/5L/ACy3ElqUYhuvAAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABn0lEQVRIie2Vvy5EURDGvyMUkhUU/pS2Q2clwvIKqL0Cm9ArrBcQShJPoLFR2YaIhIjQ7a7E39IiCgqVn8KsPY697E3oTHPumTPf990z986M9Mfm/A0wKGlMUlnSlnPuOQQAE5LOnXOFWErAIvBK1S6BZBAzZ2fzcckHjXwVaAXSwD2wWYN8A2iKK1ABt3m+ZeDRnseIthdgDxioxd1o662tfZIO7Lnf8xcklST1StqRdORxNEualHQIDDvnTmvdIGE5vwdWgLy93bQX0w0UgSdgKMC3AdfA7ndpSgKbduUbYBoI/7Ju4BiYrYFfAl4iBbxAgOyPgV9xWYDQ3xCXKK79C/wL/KJZoeW8QpsJCy0C54AMULaGmQu7sIAW4MpaxTKwbQU3U4dAxmLzwLpxXAIJP2jKgkY8Xx4o1SFwBmx7+7RxTUnVb9Bpa9HDFiR1/SRgWH+6FT3/h2qK6sBpB0aBB7yB880NcpaWtGHXjCsVBmb5PDIvgJ46BJKW84q9AguV87Adp/Q+9O8UMfQjRBKSxiV1SNp3zp3Ug/sVewPruexhKwhGXQAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Search for pull requests in GitHub repositories using issues search syntax already scoped to is:pr",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "order": {
+              "type": "string",
+              "description": "Sort order",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            },
+            "owner": {
+              "type": "string",
+              "description": "Optional repository owner. If provided with repo, only pull requests for this repository are listed."
+            },
+            "page": {
+              "type": "number",
+              "description": "Page number for pagination (min 1)",
+              "minimum": 1
+            },
+            "perPage": {
+              "type": "number",
+              "description": "Results per page for pagination (min 1, max 100)",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "query": {
+              "type": "string",
+              "description": "Search query using GitHub pull request search syntax"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Optional repository name. If provided with owner, only pull requests for this repository are listed."
+            },
+            "sort": {
+              "type": "string",
+              "description": "Sort field by number of matches of categories, defaults to best match",
+              "enum": [
+                "comments",
+                "reactions",
+                "reactions-+1",
+                "reactions--1",
+                "reactions-smile",
+                "reactions-thinking_face",
+                "reactions-heart",
+                "reactions-tada",
+                "interactions",
+                "created",
+                "updated"
+              ]
+            }
+          },
+          "required": [
+            "query"
+          ]
+        },
+        "annotations": {
+          "title": "Search pull requests",
+          "readOnlyHint": true
+        }
+      },
+      {
+        "name": "search_repositories",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Find GitHub repositories by name, description, readme, topics, or other metadata. Perfect for discovering projects, finding examples, or locating specific repositories across GitHub.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "minimal_output": {
+              "type": "boolean",
+              "description": "Return minimal repository information (default: true). When false, returns full GitHub API repository objects.",
+              "default": true
+            },
+            "order": {
+              "type": "string",
+              "description": "Sort order",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            },
+            "page": {
+              "type": "number",
+              "description": "Page number for pagination (min 1)",
+              "minimum": 1
+            },
+            "perPage": {
+              "type": "number",
+              "description": "Results per page for pagination (min 1, max 100)",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "query": {
+              "type": "string",
+              "description": "Repository search query. Examples: 'machine learning in:name stars:>1000 language:python', 'topic:react', 'user:facebook'. Supports advanced search syntax for precise filtering."
+            },
+            "sort": {
+              "type": "string",
+              "description": "Sort repositories by field, defaults to best match",
+              "enum": [
+                "stars",
+                "forks",
+                "help-wanted-issues",
+                "updated"
+              ]
+            }
+          },
+          "required": [
+            "query"
+          ]
+        },
+        "annotations": {
+          "title": "Search repositories",
+          "readOnlyHint": true
+        }
+      },
+      {
+        "name": "search_users",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAADWklEQVRIidWTT2hcVRTGf+e+mUn9Q3WMqbbWgJ1JnMw4meiAUkoxIRG1IKK4ELqoVkQXUsVuXbropoq4EWykuBDURV2I0r9GrC0VopnXTGaefYkhDahBOg4SnSTv3eMiTphMJ6Spq57dPd+933e/794DN3rJWkA+n49W54MB4AE1aoyawqVS1xn4PPzfAsnUg48iOgyaaIJ8I7r/5wn3u2sVMM2N7nTvbsQeB42J6nOOrW12bG2zIs8ohFblZHe6d/d1Oejv74/MzlU8lGibCfqKxeKVRrwzm43HAlMAatvviqdHRkaC9QScxkVk021DwAFRfalcGv+xeXN1bq52x5ats8Crf80vnL3yx29TiZ7e59s7tg7Ft3TEc5n09PT0tG08syoiEckBGF04seaVFtuOA1ixuf9OvQP6rqj5avb3SmlHKptdU0BhaT3L1gbLsVpRgMlSYdvNUb1VlKeAqBFzsjObjbcWMNYFCMxNg2sJmE3B4wCOmEK957ru/KVy4UtxnCeBO2OheaOONX9Tk+zJlRXsUsTunLl4sdIIplKp9oC2MYR//FJ3T6uZSKZzZ7Es+OXCIECkOQFVeUFET8UCU0im+w7WMydWeyKwHEboUCuDaw2cKGpFVx76qjmYLI+dRzkE3IvqZ0RrVaK1KsqnCNsROTTpjX3fijyReSip8LCo+aFlRN3d2ZR15COQnUAFOIVwedmbdCI6CMSBc47V/Z7neivkqWxexHwC2h4lmi2VRn9dJZC4Pzcghi9Qaoq8dfstztHR0dFVvyqfz0f/nA9fFNG3gRhqnvbLP30LkOzJfQP0Kzw7WSocW+Vg+ebmAjCjTrhncnz8cqsI6rUjk+80NvgauMex+ojnuV4ynTuMcgD4G/RNv+QO199ArGOGUWrXQg4wVRydCTF7gCVr5Agg/kThIE6YQjkH8mEi1bcPQLp6+h5T9AToy37JPbIeeWN1pXOvqPKBFR2amnBPA2QymdiidY4pMmhCEgbsXqDSZsKPN0IOoIvzR4GqsbK33isWi4vG8hogoaOvG0V2oXK6WCwublTA9/0FgTMIuxr7nuf+AowIDBjgboz6GyVfcSF4wLarAGEcuC8iyj4JuXC9Ak5o3g8j4fnmvpXIe44NWg7kjVX/Ap7dYx0LcmfJAAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAB20lEQVRIidXUvUuVcRQH8PPc1JYUrKWUDCmwoKa2QsTKoKEwxWhr6G1tqDVqaAn8F6I5oS0ipBp6WZqiAi1bEgIrIpcorD4NHvFye+7Vrkv94Dc853zP93venl/E/36Keg60RsRgROyOiEpEPI+IB0VR/FyzKgYw48/zBv1rJe/HN7zDKNrzDmMqfc2JoAVvk3xjib8zfa/R0ozA4WzFaAPMWGKG8vskLuDIiqK4lMHtDTAdibmY3+9rZrSnGl+piV9YqcpY3jwREUVRdEXEhog4GhGtETGJznrZHchMhhtUcCIxh0p8u/ADV+sFV3KAU2VZYBNmE7OuDsdj3K+XYGAfvua2jGXPOzLz2VzT/Q3iH2GykUCByyU/2dK50iB2B77jWj3ATjxNos+4hfG8E2mDJ+irid2LaXzCljLyQcxjDmctvkW1mFacwwd8wUCV72GKH6+X+TxeYGvd/i3je/AqRfrSNo6F5DldDS6y5LnVkFfFbcPHHGqRtu24i184tQQcytLOrJa8SuR8xh6ssrXhTm5bd+BmDq+tCYH12aYbNfbe3KbrYfH9mPhb8iqy25gusd/Ds0pEbI6ImWYFImI6IrpK7C8jojcwgu5m2dGFYyX2How0y/vvnN8dpHfeBcHNQgAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Find GitHub users by username, real name, or other profile information. Useful for locating developers, contributors, or team members.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "order": {
+              "type": "string",
+              "description": "Sort order",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            },
+            "page": {
+              "type": "number",
+              "description": "Page number for pagination (min 1)",
+              "minimum": 1
+            },
+            "perPage": {
+              "type": "number",
+              "description": "Results per page for pagination (min 1, max 100)",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "query": {
+              "type": "string",
+              "description": "User search query. Examples: 'john smith', 'location:seattle', 'followers:>100'. Search is automatically scoped to type:user."
+            },
+            "sort": {
+              "type": "string",
+              "description": "Sort users by number of followers or repositories, or when the person joined GitHub.",
+              "enum": [
+                "followers",
+                "repositories",
+                "joined"
+              ]
+            }
+          },
+          "required": [
+            "query"
+          ]
+        },
+        "annotations": {
+          "title": "Search users",
+          "readOnlyHint": true
+        }
+      },
+      {
+        "name": "sub_issue_write",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAC2UlEQVRIicWVMUyTaRjHf/+vVUpOJOdilOYoUvVreq2CDmLOwdlAS5xMbrrhBifjYG7QjYuJw108nZx1huLgYlw0QshxChUK2koxHHcuCmgsFfieG0or3kGPSoz/8X3f5/97nvfN8z7wmaVqm9FodFfR/EnMugy5giCAwYwgI9Ff9Hl9L9Lp1zUBgsGO+rqGwnlhF4CdwBSyAUwvS1G220zHBSFgHtmVxYWvfp2ZGSj8LyAcjgfZphTQZtAr7OdsZvSP9RIJR+LtQhcNusF+d1aUfPp05M8NAavmg8AOk3cmN56+s1Hpa7U/cviUYbcw3jgex9ZCKoBgsKM+0PDuAdBq2He5zOiTzZiXtc+NxRw598GeLRcWTuTz+UUAp3ygrqFwHmgzeWdqNQd4PpFOy/gedNQfaDz3UQXRaHRX0fNPGdzNZUZO12q+VuHIoV7g5Hu/1/IinX7tABTNnwR2SvRsxRzAzOsBGuuWfAkoX5FZFzCVHR95tFVAbiI9DEwj6wLwl5YVMTRYLTDsxjuRrgGYYz/kxkbvbXRWMOBB24cKYI9ks1X8hXQDaAaa5XG9WjImZgV71wI+m8qAv8y0t1pSmP0ITANTmHO2qqvRZDALlTdgHKyjWkx2YvQ2cHtTacMxYBhWK5DoF4TCkXj7Jg02VKsbOwI0Y+qvALZrOQXMC13cKkDSJWBuJUCqAhgbG3uF7IpBcn/k8KlPNQ+78U5QQuhy/vHjuQoAYPndwi9gw4bd2ufGYrWatxz8No50ExhaKsz9Vl6vAPL5/KKzoiTGG0fOg1oqCbvxTp/juw/M+zynu/yTwjoD58CBQ02ez/pAR4E+M69ntf3/o1Y3dqR050oAQz7P6Z6cfPRRw647MkOhUMAfaDyH+AloBKYNPRT292rQHoMOSp09J3TZlt5ezWazxX97VR3638RiX9ct+RImSyBcrDT0ETMyMp4ptRIgVX7QL6J/ALSUEwJ5rdg2AAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABxElEQVRIibWVvW4TURCFv0vlNEDcIHAkKAERJOIKSjoUArwBPwUFFaKIIngAJARCPIgdh4cgRBYt6ZIAEYEqdhpEw0fhCbkKa68dxyNtsfNzzpnZu3NhwpYGBdUqcA+4A1wEZiK0DawD74FWSml3JAJ1CngGLAIngU1gFfgZKWeAG8AFoAu8At6mlH6VtqTOqJ/UP2pDnRuQO6c27VlbrQ0Dvq121Fulag7q5qPmW18SdSqUd9Qrw4Jn9bNR21YrRQkvYixDKy/AuB3jWjocqKpdtXFU8AxrOTqZzp2PgvnaMRDUA+tB7mypG+OCZ3hbahPgRPguAR9LihaicEu9WcKxClzOi/fU1wPAk7rjgX0uEfNG3cs7mJjtE+wA5/olpZQEHgNf6K2NJyW4NeD7v7c4WptjSc0svlMjdzyM2fbdOyOA7x/T+7mzGj9H8xgIWuquevpw4HmsivkxwBdC/WJRsBKLqqPOHgH8aqybtcJlF0m1WLndUToJ5V31q9r3NOYk7Wh1Wa0PyK3HzA3l/4H3uzIrwFNgCThF7/x/AH5EylngOnAe6AAvgXcppd9DEWRE08DdeIou/RVgJaXUGYQzUfsL+zmwV7BtIq0AAAAASUVORK5CYII=",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Add a sub-issue to a parent issue in a GitHub repository.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "after_id": {
+              "type": "number",
+              "description": "The ID of the sub-issue to be prioritized after (either after_id OR before_id should be specified)"
+            },
+            "before_id": {
+              "type": "number",
+              "description": "The ID of the sub-issue to be prioritized before (either after_id OR before_id should be specified)"
+            },
+            "issue_number": {
+              "type": "number",
+              "description": "The number of the parent issue"
+            },
+            "method": {
+              "type": "string",
+              "description": "The action to perform on a single sub-issue\nOptions are:\n- 'add' - add a sub-issue to a parent issue in a GitHub repository.\n- 'remove' - remove a sub-issue from a parent issue in a GitHub repository.\n- 'reprioritize' - change the order of sub-issues within a parent issue in a GitHub repository. Use either 'after_id' or 'before_id' to specify the new position.\n\t\t\t\t"
+            },
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "replace_parent": {
+              "type": "boolean",
+              "description": "When true, replaces the sub-issue's current parent issue. Use with 'add' method only."
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            },
+            "sub_issue_id": {
+              "type": "number",
+              "description": "The ID of the sub-issue to add. ID is not the same as issue number"
+            }
+          },
+          "required": [
+            "method",
+            "owner",
+            "repo",
+            "issue_number",
+            "sub_issue_id"
+          ]
+        },
+        "annotations": {
+          "title": "Change sub-issue"
+        }
+      },
+      {
+        "name": "update_pull_request",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACwUlEQVRIie2Vz28UZRjHP993pi0QIC3YahNjirtmd3bS3Q1eUHvQEPUiEv8A4kXjwRJ78MCFBLjBBRKCHowHE38cNCbGGx6IUoKiodtNpoNmTJp4oSJNQ3pw29l5POxus2wo3QTwxPc0887zfD7zvu9kXnjEUfdNrjj5vJOmMP4e9JrfR1G02tuQD8tvgpck0dxCPwK30ViqnJTcr4bOmfRlI/PrhUJ5313woDpDpu8ss7f6nYHrvDnGcYlPsoY/bKaXwHY3HWfvgmNnMX0zvMM7069A3c3pkEYWa7UVgFxQPSfs7SSeH3k2rEy5jMubMBoG1yQ+SBbm53of+gCybMkk/H8VAFdbZisZLAFsJ11oyL+BUURcwrjWAZixXeIwxs/5UuVAr0QAYRjubGR+HWy3mb6QCIBXQe8nce0jgIkwfMo3/xLG085x8I9ofkMyUa0O+w2rgS0mcf3lboEDiKJo1cvsIDDr4D1DhTb8407hYhTdTJW+AvrdMnuhG9Je1m9BBzbfjXbyQcXypeqJLQt7+0rVE/mgYr3j7l7FDzOPBY8FDx6vc1EolPeNjI5/Jpgw7Lm9o+Pry//c/K0PhnLFyrSMDxE79jwxvn9079gvt28vrUD7V1EoFHalbltd2C7DfS4sAF4DTSdx7cL96LliZVriPPADuL+geRh0Z8il5SiKVn2ATENvCCYw78U/b8xdBcgHlYuGHQXuK5A4ClxM4vnXW8Lqp5JdWWt6h4CvWnsgxgDSbRZ3Gg0tCJ7sY4nGwDZOt/WBZtzN9FswLgM2sGann5mcPDaw5pWEHQH7cUu86SdkR3LF6tfrA814MNVpwNrM1leUxPXrSKfMeHcwdctyNotY8c3NbMX3LJsB3ZHsymDqlkHvYHYyievXWxPpSj4o75eYIuPWZof+vRKG4c61pncIx6gZsx34/5L/ACy3ElqUYhuvAAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABn0lEQVRIie2Vvy5EURDGvyMUkhUU/pS2Q2clwvIKqL0Cm9ArrBcQShJPoLFR2YaIhIjQ7a7E39IiCgqVn8KsPY697E3oTHPumTPf990z986M9Mfm/A0wKGlMUlnSlnPuOQQAE5LOnXOFWErAIvBK1S6BZBAzZ2fzcckHjXwVaAXSwD2wWYN8A2iKK1ABt3m+ZeDRnseIthdgDxioxd1o662tfZIO7Lnf8xcklST1StqRdORxNEualHQIDDvnTmvdIGE5vwdWgLy93bQX0w0UgSdgKMC3AdfA7ndpSgKbduUbYBoI/7Ju4BiYrYFfAl4iBbxAgOyPgV9xWYDQ3xCXKK79C/wL/KJZoeW8QpsJCy0C54AMULaGmQu7sIAW4MpaxTKwbQU3U4dAxmLzwLpxXAIJP2jKgkY8Xx4o1SFwBmx7+7RxTUnVb9Bpa9HDFiR1/SRgWH+6FT3/h2qK6sBpB0aBB7yB880NcpaWtGHXjCsVBmb5PDIvgJ46BJKW84q9AguV87Adp/Q+9O8UMfQjRBKSxiV1SNp3zp3Ug/sVewPruexhKwhGXQAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Update an existing pull request in a GitHub repository.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "base": {
+              "type": "string",
+              "description": "New base branch name"
+            },
+            "body": {
+              "type": "string",
+              "description": "New description"
+            },
+            "draft": {
+              "type": "boolean",
+              "description": "Mark pull request as draft (true) or ready for review (false)"
+            },
+            "maintainer_can_modify": {
+              "type": "boolean",
+              "description": "Allow maintainer edits"
+            },
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "pullNumber": {
+              "type": "number",
+              "description": "Pull request number to update"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            },
+            "reviewers": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "GitHub usernames to request reviews from"
+            },
+            "state": {
+              "type": "string",
+              "description": "New state",
+              "enum": [
+                "open",
+                "closed"
+              ]
+            },
+            "title": {
+              "type": "string",
+              "description": "New title"
+            }
+          },
+          "required": [
+            "owner",
+            "repo",
+            "pullNumber"
+          ]
+        },
+        "annotations": {
+          "title": "Edit pull request"
+        }
+      },
+      {
+        "name": "update_pull_request_branch",
+        "icons": [
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACwUlEQVRIie2Vz28UZRjHP993pi0QIC3YahNjirtmd3bS3Q1eUHvQEPUiEv8A4kXjwRJ78MCFBLjBBRKCHowHE38cNCbGGx6IUoKiodtNpoNmTJp4oSJNQ3pw29l5POxus2wo3QTwxPc0887zfD7zvu9kXnjEUfdNrjj5vJOmMP4e9JrfR1G02tuQD8tvgpck0dxCPwK30ViqnJTcr4bOmfRlI/PrhUJ5313woDpDpu8ss7f6nYHrvDnGcYlPsoY/bKaXwHY3HWfvgmNnMX0zvMM7069A3c3pkEYWa7UVgFxQPSfs7SSeH3k2rEy5jMubMBoG1yQ+SBbm53of+gCybMkk/H8VAFdbZisZLAFsJ11oyL+BUURcwrjWAZixXeIwxs/5UuVAr0QAYRjubGR+HWy3mb6QCIBXQe8nce0jgIkwfMo3/xLG085x8I9ofkMyUa0O+w2rgS0mcf3lboEDiKJo1cvsIDDr4D1DhTb8407hYhTdTJW+AvrdMnuhG9Je1m9BBzbfjXbyQcXypeqJLQt7+0rVE/mgYr3j7l7FDzOPBY8FDx6vc1EolPeNjI5/Jpgw7Lm9o+Pry//c/K0PhnLFyrSMDxE79jwxvn9079gvt28vrUD7V1EoFHalbltd2C7DfS4sAF4DTSdx7cL96LliZVriPPADuL+geRh0Z8il5SiKVn2ATENvCCYw78U/b8xdBcgHlYuGHQXuK5A4ClxM4vnXW8Lqp5JdWWt6h4CvWnsgxgDSbRZ3Gg0tCJ7sY4nGwDZOt/WBZtzN9FswLgM2sGann5mcPDaw5pWEHQH7cUu86SdkR3LF6tfrA814MNVpwNrM1leUxPXrSKfMeHcwdctyNotY8c3NbMX3LJsB3ZHsymDqlkHvYHYyievXWxPpSj4o75eYIuPWZof+vRKG4c61pncIx6gZsx34/5L/ACy3ElqUYhuvAAAAAElFTkSuQmCC",
+            "mimeType": "image/png",
+            "theme": "light"
+          },
+          {
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABn0lEQVRIie2Vvy5EURDGvyMUkhUU/pS2Q2clwvIKqL0Cm9ArrBcQShJPoLFR2YaIhIjQ7a7E39IiCgqVn8KsPY697E3oTHPumTPf990z986M9Mfm/A0wKGlMUlnSlnPuOQQAE5LOnXOFWErAIvBK1S6BZBAzZ2fzcckHjXwVaAXSwD2wWYN8A2iKK1ABt3m+ZeDRnseIthdgDxioxd1o662tfZIO7Lnf8xcklST1StqRdORxNEualHQIDDvnTmvdIGE5vwdWgLy93bQX0w0UgSdgKMC3AdfA7ndpSgKbduUbYBoI/7Ju4BiYrYFfAl4iBbxAgOyPgV9xWYDQ3xCXKK79C/wL/KJZoeW8QpsJCy0C54AMULaGmQu7sIAW4MpaxTKwbQU3U4dAxmLzwLpxXAIJP2jKgkY8Xx4o1SFwBmx7+7RxTUnVb9Bpa9HDFiR1/SRgWH+6FT3/h2qK6sBpB0aBB7yB880NcpaWtGHXjCsVBmb5PDIvgJ46BJKW84q9AguV87Adp/Q+9O8UMfQjRBKSxiV1SNp3zp3Ug/sVewPruexhKwhGXQAAAABJRU5ErkJggg==",
+            "mimeType": "image/png",
+            "theme": "dark"
+          }
+        ],
+        "description": "Update the branch of a pull request with the latest changes from the base branch.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "expectedHeadSha": {
+              "type": "string",
+              "description": "The expected SHA of the pull request's HEAD ref"
+            },
+            "owner": {
+              "type": "string",
+              "description": "Repository owner"
+            },
+            "pullNumber": {
+              "type": "number",
+              "description": "Pull request number"
+            },
+            "repo": {
+              "type": "string",
+              "description": "Repository name"
+            }
+          },
+          "required": [
+            "owner",
+            "repo",
+            "pullNumber"
+          ]
+        },
+        "annotations": {
+          "title": "Update pull request branch"
+        }
+      }
+    ]
+  },
+  "normalized_bundle": {
+    "operations": [
+      {
+        "source_tool_name": "add_comment_to_pending_review",
+        "operation_name": "add_comment_to_pending_review",
+        "title": "Add review comment to the requester's latest pending pull request review",
+        "description": "Add review comment to the requester's latest pending pull request review. A pending review needs to already exist to call this (check with the user if not sure).",
+        "endpoint": "CREATE",
+        "endpoint_confidence": "high",
+        "danger_level": "reversible",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "body",
+            "original_name": "body",
+            "type": "string",
+            "required": true,
+            "description": "The text of the review comment",
+            "source_path": "inputSchema.properties.body"
+          },
+          {
+            "name": "line",
+            "original_name": "line",
+            "type": "number",
+            "required": false,
+            "description": "The line of the blob in the pull request diff that the comment applies to. For multi-line comments, the last line of the range",
+            "source_path": "inputSchema.properties.line"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "path",
+            "original_name": "path",
+            "type": "string",
+            "required": true,
+            "description": "The relative path to the file that necessitates a comment",
+            "source_path": "inputSchema.properties.path"
+          },
+          {
+            "name": "pull_number",
+            "original_name": "pullNumber",
+            "type": "number",
+            "required": true,
+            "description": "Pull request number",
+            "source_path": "inputSchema.properties.pullNumber"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          },
+          {
+            "name": "side",
+            "original_name": "side",
+            "type": "string",
+            "required": false,
+            "description": "The side of the diff to comment on. LEFT indicates the previous state, RIGHT indicates the new state",
+            "enum": [
+              "LEFT",
+              "RIGHT"
+            ],
+            "source_path": "inputSchema.properties.side"
+          },
+          {
+            "name": "start_line",
+            "original_name": "startLine",
+            "type": "number",
+            "required": false,
+            "description": "For multi-line comments, the first line of the range that the comment applies to",
+            "source_path": "inputSchema.properties.startLine"
+          },
+          {
+            "name": "start_side",
+            "original_name": "startSide",
+            "type": "string",
+            "required": false,
+            "description": "For multi-line comments, the starting side of the diff that the comment applies to. LEFT indicates the previous state, RIGHT indicates the new state",
+            "enum": [
+              "LEFT",
+              "RIGHT"
+            ],
+            "source_path": "inputSchema.properties.startSide"
+          },
+          {
+            "name": "subject_type",
+            "original_name": "subjectType",
+            "type": "string",
+            "required": true,
+            "description": "The level at which the comment is targeted",
+            "enum": [
+              "FILE",
+              "LINE"
+            ],
+            "source_path": "inputSchema.properties.subjectType"
+          }
+        ],
+        "maps_to": "tool:add_comment_to_pending_review",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "add_issue_comment",
+        "operation_name": "add_issue_comment",
+        "title": "Add comment to issue",
+        "description": "Add a comment to a specific issue in a GitHub repository. Use this tool to add comments to pull requests as well (in this case pass pull request number as issue_number), but only if user is not asking specifically to add review comments.",
+        "endpoint": "CREATE",
+        "endpoint_confidence": "high",
+        "danger_level": "reversible",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "body",
+            "original_name": "body",
+            "type": "string",
+            "required": true,
+            "description": "Comment content",
+            "source_path": "inputSchema.properties.body"
+          },
+          {
+            "name": "issue_number",
+            "original_name": "issue_number",
+            "type": "number",
+            "required": true,
+            "description": "Issue number to comment on",
+            "source_path": "inputSchema.properties.issue_number"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          }
+        ],
+        "maps_to": "tool:add_issue_comment",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "add_reply_to_pull_request_comment",
+        "operation_name": "add_reply_to_pull_request_comment",
+        "title": "Add reply to pull request comment",
+        "description": "Add a reply to an existing pull request comment. This creates a new comment that is linked as a reply to the specified comment.",
+        "endpoint": "CREATE",
+        "endpoint_confidence": "high",
+        "danger_level": "reversible",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "body",
+            "original_name": "body",
+            "type": "string",
+            "required": true,
+            "description": "The text of the reply",
+            "source_path": "inputSchema.properties.body"
+          },
+          {
+            "name": "comment_id",
+            "original_name": "commentId",
+            "type": "number",
+            "required": true,
+            "description": "The ID of the comment to reply to",
+            "source_path": "inputSchema.properties.commentId"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "pull_number",
+            "original_name": "pullNumber",
+            "type": "number",
+            "required": true,
+            "description": "Pull request number",
+            "source_path": "inputSchema.properties.pullNumber"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          }
+        ],
+        "maps_to": "tool:add_reply_to_pull_request_comment",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "assign_copilot_to_issue",
+        "operation_name": "assign_copilot_to_issue",
+        "title": "Assign Copilot to issue",
+        "description": "Assign Copilot to a specific issue in a GitHub repository.\n\nThis tool can help with the following outcomes:\n- a Pull Request created with source code changes to resolve the issue\n\n\nMore information can be found at:\n- https://docs.github.com/en/copilot/using-github-copilot/using-copilot-coding-agent-to-work-on-tasks/about-assigning-tasks-to-copilot\n",
+        "endpoint": "CREATE",
+        "endpoint_confidence": "high",
+        "danger_level": "reversible",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "base_ref",
+            "original_name": "base_ref",
+            "type": "string",
+            "required": false,
+            "description": "Git reference (e.g., branch) that the agent will start its work from. If not specified, defaults to the repository's default branch",
+            "source_path": "inputSchema.properties.base_ref"
+          },
+          {
+            "name": "custom_instructions",
+            "original_name": "custom_instructions",
+            "type": "string",
+            "required": false,
+            "description": "Optional custom instructions to guide the agent beyond the issue body. Use this to provide additional context, constraints, or guidance that is not captured in the issue description",
+            "source_path": "inputSchema.properties.custom_instructions"
+          },
+          {
+            "name": "issue_number",
+            "original_name": "issue_number",
+            "type": "number",
+            "required": true,
+            "description": "Issue number",
+            "source_path": "inputSchema.properties.issue_number"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          }
+        ],
+        "maps_to": "tool:assign_copilot_to_issue",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "idempotentHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "create_branch",
+        "operation_name": "create_branch",
+        "title": "Create branch",
+        "description": "Create a new branch in a GitHub repository",
+        "endpoint": "CREATE",
+        "endpoint_confidence": "high",
+        "danger_level": "reversible",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "branch",
+            "original_name": "branch",
+            "type": "string",
+            "required": true,
+            "description": "Name for new branch",
+            "source_path": "inputSchema.properties.branch"
+          },
+          {
+            "name": "from_branch",
+            "original_name": "from_branch",
+            "type": "string",
+            "required": false,
+            "description": "Source branch (defaults to repo default)",
+            "source_path": "inputSchema.properties.from_branch"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          }
+        ],
+        "maps_to": "tool:create_branch",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "create_or_update_file",
+        "operation_name": "create_or_update_file",
+        "title": "Create or update file",
+        "description": "Create or update a single file in a GitHub repository. \nIf updating, you should provide the SHA of the file you want to update. Use this tool to create or update a file in a GitHub repository remotely; do not use it for local file operations.\n\nIn order to obtain the SHA of original file version before updating, use the following git command:\ngit rev-parse <branch>:<path to file>\n\nSHA MUST be provided for existing file updates.\n",
+        "endpoint": "UPDATE",
+        "endpoint_confidence": "low",
+        "danger_level": "reversible",
+        "needs_review": true,
+        "review_reasons": [
+          "Tool name spans both create and update semantics."
+        ],
+        "params": [
+          {
+            "name": "branch",
+            "original_name": "branch",
+            "type": "string",
+            "required": true,
+            "description": "Branch to create/update the file in",
+            "source_path": "inputSchema.properties.branch"
+          },
+          {
+            "name": "content",
+            "original_name": "content",
+            "type": "string",
+            "required": true,
+            "description": "Content of the file",
+            "source_path": "inputSchema.properties.content"
+          },
+          {
+            "name": "message",
+            "original_name": "message",
+            "type": "string",
+            "required": true,
+            "description": "Commit message",
+            "source_path": "inputSchema.properties.message"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner (username or organization)",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "path",
+            "original_name": "path",
+            "type": "string",
+            "required": true,
+            "description": "Path where to create/update the file",
+            "source_path": "inputSchema.properties.path"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          },
+          {
+            "name": "sha",
+            "original_name": "sha",
+            "type": "string",
+            "required": false,
+            "description": "The blob SHA of the file being replaced. Required if the file already exists.",
+            "source_path": "inputSchema.properties.sha"
+          }
+        ],
+        "maps_to": "tool:create_or_update_file",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "create_pull_request",
+        "operation_name": "create_pull_request",
+        "title": "Open new pull request",
+        "description": "Create a new pull request in a GitHub repository.",
+        "endpoint": "CREATE",
+        "endpoint_confidence": "high",
+        "danger_level": "reversible",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "base",
+            "original_name": "base",
+            "type": "string",
+            "required": true,
+            "description": "Branch to merge into",
+            "source_path": "inputSchema.properties.base"
+          },
+          {
+            "name": "body",
+            "original_name": "body",
+            "type": "string",
+            "required": false,
+            "description": "PR description",
+            "source_path": "inputSchema.properties.body"
+          },
+          {
+            "name": "draft",
+            "original_name": "draft",
+            "type": "boolean",
+            "required": false,
+            "description": "Create as draft PR",
+            "source_path": "inputSchema.properties.draft"
+          },
+          {
+            "name": "head",
+            "original_name": "head",
+            "type": "string",
+            "required": true,
+            "description": "Branch containing changes",
+            "source_path": "inputSchema.properties.head"
+          },
+          {
+            "name": "maintainer_can_modify",
+            "original_name": "maintainer_can_modify",
+            "type": "boolean",
+            "required": false,
+            "description": "Allow maintainer edits",
+            "source_path": "inputSchema.properties.maintainer_can_modify"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          },
+          {
+            "name": "title",
+            "original_name": "title",
+            "type": "string",
+            "required": true,
+            "description": "PR title",
+            "source_path": "inputSchema.properties.title"
+          }
+        ],
+        "maps_to": "tool:create_pull_request",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "create_pull_request_with_copilot",
+        "operation_name": "create_pull_request_with_copilot",
+        "title": "Perform task with GitHub Copilot coding agent",
+        "description": "Delegate a task to GitHub Copilot coding agent to perform in the background. The agent will create a pull request with the implementation. You should use this tool if the user asks to create a pull request to perform a specific task, or if the user asks Copilot to do something.",
+        "endpoint": "CREATE",
+        "endpoint_confidence": "high",
+        "danger_level": "reversible",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "base_ref",
+            "original_name": "base_ref",
+            "type": "string",
+            "required": false,
+            "description": "Git reference (e.g., branch) that the agent will start its work from. If not specified, defaults to the repository's default branch",
+            "source_path": "inputSchema.properties.base_ref"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner. You can guess the owner, but confirm it with the user before proceeding.",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "problem_statement",
+            "original_name": "problem_statement",
+            "type": "string",
+            "required": true,
+            "description": "Detailed description of the task to be performed (e.g., 'Implement a feature that does X', 'Fix bug Y', etc.)",
+            "source_path": "inputSchema.properties.problem_statement"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name. You can guess the repository name, but confirm it with the user before proceeding.",
+            "source_path": "inputSchema.properties.repo"
+          },
+          {
+            "name": "title",
+            "original_name": "title",
+            "type": "string",
+            "required": true,
+            "description": "Title for the pull request that will be created",
+            "source_path": "inputSchema.properties.title"
+          }
+        ],
+        "maps_to": "tool:create_pull_request_with_copilot",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "openWorldHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "create_repository",
+        "operation_name": "create_repository",
+        "title": "Create repository",
+        "description": "Create a new GitHub repository in your account or specified organization",
+        "endpoint": "CREATE",
+        "endpoint_confidence": "high",
+        "danger_level": "reversible",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "auto_init",
+            "original_name": "autoInit",
+            "type": "boolean",
+            "required": false,
+            "description": "Initialize with README",
+            "source_path": "inputSchema.properties.autoInit"
+          },
+          {
+            "name": "description",
+            "original_name": "description",
+            "type": "string",
+            "required": false,
+            "description": "Repository description",
+            "source_path": "inputSchema.properties.description"
+          },
+          {
+            "name": "name",
+            "original_name": "name",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.name"
+          },
+          {
+            "name": "organization",
+            "original_name": "organization",
+            "type": "string",
+            "required": false,
+            "description": "Organization to create the repository in (omit to create in your personal account)",
+            "source_path": "inputSchema.properties.organization"
+          },
+          {
+            "name": "private",
+            "original_name": "private",
+            "type": "boolean",
+            "required": false,
+            "description": "Whether repo should be private",
+            "source_path": "inputSchema.properties.private"
+          }
+        ],
+        "maps_to": "tool:create_repository",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "delete_file",
+        "operation_name": "delete_file",
+        "title": "Delete file",
+        "description": "Delete a file from a GitHub repository",
+        "endpoint": "DELETE",
+        "endpoint_confidence": "high",
+        "danger_level": "destructive",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "branch",
+            "original_name": "branch",
+            "type": "string",
+            "required": true,
+            "description": "Branch to delete the file from",
+            "source_path": "inputSchema.properties.branch"
+          },
+          {
+            "name": "message",
+            "original_name": "message",
+            "type": "string",
+            "required": true,
+            "description": "Commit message",
+            "source_path": "inputSchema.properties.message"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner (username or organization)",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "path",
+            "original_name": "path",
+            "type": "string",
+            "required": true,
+            "description": "Path to the file to delete",
+            "source_path": "inputSchema.properties.path"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          }
+        ],
+        "maps_to": "tool:delete_file",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "destructiveHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "fork_repository",
+        "operation_name": "fork_repository",
+        "title": "Fork repository",
+        "description": "Fork a GitHub repository to your account or specified organization",
+        "endpoint": "CREATE",
+        "endpoint_confidence": "high",
+        "danger_level": "reversible",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "organization",
+            "original_name": "organization",
+            "type": "string",
+            "required": false,
+            "description": "Organization to fork to",
+            "source_path": "inputSchema.properties.organization"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          }
+        ],
+        "maps_to": "tool:fork_repository",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "get_commit",
+        "operation_name": "get_commit",
+        "title": "Get commit details",
+        "description": "Get details for a commit from a GitHub repository",
+        "endpoint": "READ",
+        "endpoint_confidence": "high",
+        "danger_level": "safe",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "include_diff",
+            "original_name": "include_diff",
+            "type": "boolean",
+            "required": false,
+            "description": "Whether to include file diffs and stats in the response. Default is true.",
+            "default": true,
+            "source_path": "inputSchema.properties.include_diff"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "page",
+            "original_name": "page",
+            "type": "number",
+            "required": false,
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1,
+            "source_path": "inputSchema.properties.page"
+          },
+          {
+            "name": "per_page",
+            "original_name": "perPage",
+            "type": "number",
+            "required": false,
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100,
+            "source_path": "inputSchema.properties.perPage"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          },
+          {
+            "name": "sha",
+            "original_name": "sha",
+            "type": "string",
+            "required": true,
+            "description": "Commit SHA, branch name, or tag name",
+            "source_path": "inputSchema.properties.sha"
+          }
+        ],
+        "maps_to": "tool:get_commit",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "readOnlyHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "get_copilot_job_status",
+        "operation_name": "get_copilot_job_status",
+        "title": "Get Copilot coding agent job status",
+        "description": "Get the status of a GitHub Copilot coding agent job. Use this to check if a previously submitted task has completed and to get the pull request URL once it's created. Provide the job ID (from create_pull_request_with_copilot) or pull request number (from assign_copilot_to_issue), or any pull request you want agent sessions for.",
+        "endpoint": "READ",
+        "endpoint_confidence": "high",
+        "danger_level": "safe",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "id",
+            "original_name": "id",
+            "type": "string",
+            "required": true,
+            "description": "Job ID or pull request number",
+            "source_path": "inputSchema.properties.id"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          }
+        ],
+        "maps_to": "tool:get_copilot_job_status",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "readOnlyHint",
+            "openWorldHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "get_file_contents",
+        "operation_name": "get_file_contents",
+        "title": "Get file or directory contents",
+        "description": "Get the contents of a file or directory from a GitHub repository",
+        "endpoint": "READ",
+        "endpoint_confidence": "high",
+        "danger_level": "safe",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner (username or organization)",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "path",
+            "original_name": "path",
+            "type": "string",
+            "required": false,
+            "description": "Path to file/directory",
+            "default": "/",
+            "source_path": "inputSchema.properties.path"
+          },
+          {
+            "name": "ref",
+            "original_name": "ref",
+            "type": "string",
+            "required": false,
+            "description": "Accepts optional git refs such as `refs/tags/{tag}`, `refs/heads/{branch}` or `refs/pull/{pr_number}/head`",
+            "source_path": "inputSchema.properties.ref"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          },
+          {
+            "name": "sha",
+            "original_name": "sha",
+            "type": "string",
+            "required": false,
+            "description": "Accepts optional commit SHA. If specified, it will be used instead of ref",
+            "source_path": "inputSchema.properties.sha"
+          }
+        ],
+        "maps_to": "tool:get_file_contents",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "readOnlyHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "get_label",
+        "operation_name": "get_label",
+        "title": "Get a specific label from a repository.",
+        "description": "Get a specific label from a repository.",
+        "endpoint": "READ",
+        "endpoint_confidence": "high",
+        "danger_level": "safe",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "name",
+            "original_name": "name",
+            "type": "string",
+            "required": true,
+            "description": "Label name.",
+            "source_path": "inputSchema.properties.name"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner (username or organization name)",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          }
+        ],
+        "maps_to": "tool:get_label",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "readOnlyHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "get_latest_release",
+        "operation_name": "get_latest_release",
+        "title": "Get latest release",
+        "description": "Get the latest release in a GitHub repository",
+        "endpoint": "READ",
+        "endpoint_confidence": "high",
+        "danger_level": "safe",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          }
+        ],
+        "maps_to": "tool:get_latest_release",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "readOnlyHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "get_me",
+        "operation_name": "get_me",
+        "title": "Get my user profile",
+        "description": "Get details of the authenticated GitHub user. Use this when a request is about the user's own profile for GitHub. Or when information is missing to build other tool calls.",
+        "endpoint": "READ",
+        "endpoint_confidence": "high",
+        "danger_level": "safe",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [],
+        "maps_to": "tool:get_me",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "readOnlyHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "get_release_by_tag",
+        "operation_name": "get_release_by_tag",
+        "title": "Get a release by tag name",
+        "description": "Get a specific release by its tag name in a GitHub repository",
+        "endpoint": "READ",
+        "endpoint_confidence": "high",
+        "danger_level": "safe",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          },
+          {
+            "name": "tag",
+            "original_name": "tag",
+            "type": "string",
+            "required": true,
+            "description": "Tag name (e.g., 'v1.0.0')",
+            "source_path": "inputSchema.properties.tag"
+          }
+        ],
+        "maps_to": "tool:get_release_by_tag",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "readOnlyHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "get_tag",
+        "operation_name": "get_tag",
+        "title": "Get tag details",
+        "description": "Get details about a specific git tag in a GitHub repository",
+        "endpoint": "READ",
+        "endpoint_confidence": "high",
+        "danger_level": "safe",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          },
+          {
+            "name": "tag",
+            "original_name": "tag",
+            "type": "string",
+            "required": true,
+            "description": "Tag name",
+            "source_path": "inputSchema.properties.tag"
+          }
+        ],
+        "maps_to": "tool:get_tag",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "readOnlyHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "get_team_members",
+        "operation_name": "get_team_members",
+        "title": "Get team members",
+        "description": "Get member usernames of a specific team in an organization. Limited to organizations accessible with current credentials",
+        "endpoint": "READ",
+        "endpoint_confidence": "high",
+        "danger_level": "safe",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "org",
+            "original_name": "org",
+            "type": "string",
+            "required": true,
+            "description": "Organization login (owner) that contains the team.",
+            "source_path": "inputSchema.properties.org"
+          },
+          {
+            "name": "team_slug",
+            "original_name": "team_slug",
+            "type": "string",
+            "required": true,
+            "description": "Team slug",
+            "source_path": "inputSchema.properties.team_slug"
+          }
+        ],
+        "maps_to": "tool:get_team_members",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "readOnlyHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "get_teams",
+        "operation_name": "get_teams",
+        "title": "Get teams",
+        "description": "Get details of the teams the user is a member of. Limited to organizations accessible with current credentials",
+        "endpoint": "READ",
+        "endpoint_confidence": "high",
+        "danger_level": "safe",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "user",
+            "original_name": "user",
+            "type": "string",
+            "required": false,
+            "description": "Username to get teams for. If not provided, uses the authenticated user.",
+            "source_path": "inputSchema.properties.user"
+          }
+        ],
+        "maps_to": "tool:get_teams",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "readOnlyHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "issue_read",
+        "operation_name": "issue_read",
+        "title": "Get issue details",
+        "description": "Get information about a specific issue in a GitHub repository.",
+        "endpoint": "READ",
+        "endpoint_confidence": "high",
+        "danger_level": "safe",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "issue_number",
+            "original_name": "issue_number",
+            "type": "number",
+            "required": true,
+            "description": "The number of the issue",
+            "source_path": "inputSchema.properties.issue_number"
+          },
+          {
+            "name": "method",
+            "original_name": "method",
+            "type": "string",
+            "required": true,
+            "description": "The read operation to perform on a single issue.\nOptions are:\n1. get - Get details of a specific issue.\n2. get_comments - Get issue comments.\n3. get_sub_issues - Get sub-issues of the issue.\n4. get_labels - Get labels assigned to the issue.\n",
+            "enum": [
+              "get",
+              "get_comments",
+              "get_sub_issues",
+              "get_labels"
+            ],
+            "source_path": "inputSchema.properties.method"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "The owner of the repository",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "page",
+            "original_name": "page",
+            "type": "number",
+            "required": false,
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1,
+            "source_path": "inputSchema.properties.page"
+          },
+          {
+            "name": "per_page",
+            "original_name": "perPage",
+            "type": "number",
+            "required": false,
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100,
+            "source_path": "inputSchema.properties.perPage"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "The name of the repository",
+            "source_path": "inputSchema.properties.repo"
+          }
+        ],
+        "maps_to": "tool:issue_read",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "readOnlyHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "issue_write",
+        "operation_name": "issue_write",
+        "title": "Create or update issue.",
+        "description": "Create a new or update an existing issue in a GitHub repository.",
+        "endpoint": "UPDATE",
+        "endpoint_confidence": "medium",
+        "danger_level": "reversible",
+        "needs_review": true,
+        "review_reasons": [
+          "Write suffix is semantically broad and may hide create/update behavior."
+        ],
+        "params": [
+          {
+            "name": "assignees",
+            "original_name": "assignees",
+            "type": "array",
+            "required": false,
+            "description": "Usernames to assign to this issue",
+            "source_path": "inputSchema.properties.assignees"
+          },
+          {
+            "name": "body",
+            "original_name": "body",
+            "type": "string",
+            "required": false,
+            "description": "Issue body content",
+            "source_path": "inputSchema.properties.body"
+          },
+          {
+            "name": "duplicate_of",
+            "original_name": "duplicate_of",
+            "type": "number",
+            "required": false,
+            "description": "Issue number that this issue is a duplicate of. Only used when state_reason is 'duplicate'.",
+            "source_path": "inputSchema.properties.duplicate_of"
+          },
+          {
+            "name": "issue_number",
+            "original_name": "issue_number",
+            "type": "number",
+            "required": false,
+            "description": "Issue number to update",
+            "source_path": "inputSchema.properties.issue_number"
+          },
+          {
+            "name": "labels",
+            "original_name": "labels",
+            "type": "array",
+            "required": false,
+            "description": "Labels to apply to this issue",
+            "source_path": "inputSchema.properties.labels"
+          },
+          {
+            "name": "method",
+            "original_name": "method",
+            "type": "string",
+            "required": true,
+            "description": "Write operation to perform on a single issue.\nOptions are:\n- 'create' - creates a new issue.\n- 'update' - updates an existing issue.\n",
+            "enum": [
+              "create",
+              "update"
+            ],
+            "source_path": "inputSchema.properties.method"
+          },
+          {
+            "name": "milestone",
+            "original_name": "milestone",
+            "type": "number",
+            "required": false,
+            "description": "Milestone number",
+            "source_path": "inputSchema.properties.milestone"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          },
+          {
+            "name": "state",
+            "original_name": "state",
+            "type": "string",
+            "required": false,
+            "description": "New state",
+            "enum": [
+              "open",
+              "closed"
+            ],
+            "source_path": "inputSchema.properties.state"
+          },
+          {
+            "name": "state_reason",
+            "original_name": "state_reason",
+            "type": "string",
+            "required": false,
+            "description": "Reason for the state change. Ignored unless state is changed.",
+            "enum": [
+              "completed",
+              "not_planned",
+              "duplicate"
+            ],
+            "source_path": "inputSchema.properties.state_reason"
+          },
+          {
+            "name": "title",
+            "original_name": "title",
+            "type": "string",
+            "required": false,
+            "description": "Issue title",
+            "source_path": "inputSchema.properties.title"
+          },
+          {
+            "name": "type",
+            "original_name": "type",
+            "type": "string",
+            "required": false,
+            "description": "Type of this issue. Only use if the repository has issue types configured. Use list_issue_types tool to get valid type values for the organization. If the repository doesn't support issue types, omit this parameter.",
+            "source_path": "inputSchema.properties.type"
+          }
+        ],
+        "maps_to": "tool:issue_write",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "list_branches",
+        "operation_name": "list_branches",
+        "title": "List branches",
+        "description": "List branches in a GitHub repository",
+        "endpoint": "READ",
+        "endpoint_confidence": "high",
+        "danger_level": "safe",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "page",
+            "original_name": "page",
+            "type": "number",
+            "required": false,
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1,
+            "source_path": "inputSchema.properties.page"
+          },
+          {
+            "name": "per_page",
+            "original_name": "perPage",
+            "type": "number",
+            "required": false,
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100,
+            "source_path": "inputSchema.properties.perPage"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          }
+        ],
+        "maps_to": "tool:list_branches",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "readOnlyHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "list_commits",
+        "operation_name": "list_commits",
+        "title": "List commits",
+        "description": "Get list of commits of a branch in a GitHub repository. Returns at least 30 results per page by default, but can return more if specified using the perPage parameter (up to 100).",
+        "endpoint": "READ",
+        "endpoint_confidence": "high",
+        "danger_level": "safe",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "author",
+            "original_name": "author",
+            "type": "string",
+            "required": false,
+            "description": "Author username or email address to filter commits by",
+            "source_path": "inputSchema.properties.author"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "page",
+            "original_name": "page",
+            "type": "number",
+            "required": false,
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1,
+            "source_path": "inputSchema.properties.page"
+          },
+          {
+            "name": "per_page",
+            "original_name": "perPage",
+            "type": "number",
+            "required": false,
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100,
+            "source_path": "inputSchema.properties.perPage"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          },
+          {
+            "name": "sha",
+            "original_name": "sha",
+            "type": "string",
+            "required": false,
+            "description": "Commit SHA, branch or tag name to list commits of. If not provided, uses the default branch of the repository. If a commit SHA is provided, will list commits up to that SHA.",
+            "source_path": "inputSchema.properties.sha"
+          }
+        ],
+        "maps_to": "tool:list_commits",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "readOnlyHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "list_issue_types",
+        "operation_name": "list_issue_types",
+        "title": "List available issue types",
+        "description": "List supported issue types for repository owner (organization).",
+        "endpoint": "READ",
+        "endpoint_confidence": "high",
+        "danger_level": "safe",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "The organization owner of the repository",
+            "source_path": "inputSchema.properties.owner"
+          }
+        ],
+        "maps_to": "tool:list_issue_types",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "readOnlyHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "list_issues",
+        "operation_name": "list_issues",
+        "title": "List issues",
+        "description": "List issues in a GitHub repository. For pagination, use the 'endCursor' from the previous response's 'pageInfo' in the 'after' parameter.",
+        "endpoint": "READ",
+        "endpoint_confidence": "high",
+        "danger_level": "safe",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "after",
+            "original_name": "after",
+            "type": "string",
+            "required": false,
+            "description": "Cursor for pagination. Use the endCursor from the previous page's PageInfo for GraphQL APIs.",
+            "source_path": "inputSchema.properties.after"
+          },
+          {
+            "name": "direction",
+            "original_name": "direction",
+            "type": "string",
+            "required": false,
+            "description": "Order direction. If provided, the 'orderBy' also needs to be provided.",
+            "enum": [
+              "ASC",
+              "DESC"
+            ],
+            "source_path": "inputSchema.properties.direction"
+          },
+          {
+            "name": "labels",
+            "original_name": "labels",
+            "type": "array",
+            "required": false,
+            "description": "Filter by labels",
+            "source_path": "inputSchema.properties.labels"
+          },
+          {
+            "name": "order_by",
+            "original_name": "orderBy",
+            "type": "string",
+            "required": false,
+            "description": "Order issues by field. If provided, the 'direction' also needs to be provided.",
+            "enum": [
+              "CREATED_AT",
+              "UPDATED_AT",
+              "COMMENTS"
+            ],
+            "source_path": "inputSchema.properties.orderBy"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "per_page",
+            "original_name": "perPage",
+            "type": "number",
+            "required": false,
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100,
+            "source_path": "inputSchema.properties.perPage"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          },
+          {
+            "name": "since",
+            "original_name": "since",
+            "type": "string",
+            "required": false,
+            "description": "Filter by date (ISO 8601 timestamp)",
+            "source_path": "inputSchema.properties.since"
+          },
+          {
+            "name": "state",
+            "original_name": "state",
+            "type": "string",
+            "required": false,
+            "description": "Filter by state, by default both open and closed issues are returned when not provided",
+            "enum": [
+              "OPEN",
+              "CLOSED"
+            ],
+            "source_path": "inputSchema.properties.state"
+          }
+        ],
+        "maps_to": "tool:list_issues",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "readOnlyHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "list_pull_requests",
+        "operation_name": "list_pull_requests",
+        "title": "List pull requests",
+        "description": "List pull requests in a GitHub repository. If the user specifies an author, then DO NOT use this tool and use the search_pull_requests tool instead.",
+        "endpoint": "READ",
+        "endpoint_confidence": "high",
+        "danger_level": "safe",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "base",
+            "original_name": "base",
+            "type": "string",
+            "required": false,
+            "description": "Filter by base branch",
+            "source_path": "inputSchema.properties.base"
+          },
+          {
+            "name": "direction",
+            "original_name": "direction",
+            "type": "string",
+            "required": false,
+            "description": "Sort direction",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "source_path": "inputSchema.properties.direction"
+          },
+          {
+            "name": "head",
+            "original_name": "head",
+            "type": "string",
+            "required": false,
+            "description": "Filter by head user/org and branch",
+            "source_path": "inputSchema.properties.head"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "page",
+            "original_name": "page",
+            "type": "number",
+            "required": false,
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1,
+            "source_path": "inputSchema.properties.page"
+          },
+          {
+            "name": "per_page",
+            "original_name": "perPage",
+            "type": "number",
+            "required": false,
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100,
+            "source_path": "inputSchema.properties.perPage"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          },
+          {
+            "name": "sort",
+            "original_name": "sort",
+            "type": "string",
+            "required": false,
+            "description": "Sort by",
+            "enum": [
+              "created",
+              "updated",
+              "popularity",
+              "long-running"
+            ],
+            "source_path": "inputSchema.properties.sort"
+          },
+          {
+            "name": "state",
+            "original_name": "state",
+            "type": "string",
+            "required": false,
+            "description": "Filter by state",
+            "enum": [
+              "open",
+              "closed",
+              "all"
+            ],
+            "source_path": "inputSchema.properties.state"
+          }
+        ],
+        "maps_to": "tool:list_pull_requests",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "readOnlyHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "list_releases",
+        "operation_name": "list_releases",
+        "title": "List releases",
+        "description": "List releases in a GitHub repository",
+        "endpoint": "READ",
+        "endpoint_confidence": "high",
+        "danger_level": "safe",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "page",
+            "original_name": "page",
+            "type": "number",
+            "required": false,
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1,
+            "source_path": "inputSchema.properties.page"
+          },
+          {
+            "name": "per_page",
+            "original_name": "perPage",
+            "type": "number",
+            "required": false,
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100,
+            "source_path": "inputSchema.properties.perPage"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          }
+        ],
+        "maps_to": "tool:list_releases",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "readOnlyHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "list_tags",
+        "operation_name": "list_tags",
+        "title": "List tags",
+        "description": "List git tags in a GitHub repository",
+        "endpoint": "READ",
+        "endpoint_confidence": "high",
+        "danger_level": "safe",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "page",
+            "original_name": "page",
+            "type": "number",
+            "required": false,
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1,
+            "source_path": "inputSchema.properties.page"
+          },
+          {
+            "name": "per_page",
+            "original_name": "perPage",
+            "type": "number",
+            "required": false,
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100,
+            "source_path": "inputSchema.properties.perPage"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          }
+        ],
+        "maps_to": "tool:list_tags",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "readOnlyHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "merge_pull_request",
+        "operation_name": "merge_pull_request",
+        "title": "Merge pull request",
+        "description": "Merge a pull request in a GitHub repository.",
+        "endpoint": "EXECUTE",
+        "endpoint_confidence": "medium",
+        "danger_level": "dangerous",
+        "needs_review": true,
+        "review_reasons": [
+          "Action-oriented tool classified as EXECUTE conservatively."
+        ],
+        "params": [
+          {
+            "name": "commit_message",
+            "original_name": "commit_message",
+            "type": "string",
+            "required": false,
+            "description": "Extra detail for merge commit",
+            "source_path": "inputSchema.properties.commit_message"
+          },
+          {
+            "name": "commit_title",
+            "original_name": "commit_title",
+            "type": "string",
+            "required": false,
+            "description": "Title for merge commit",
+            "source_path": "inputSchema.properties.commit_title"
+          },
+          {
+            "name": "merge_method",
+            "original_name": "merge_method",
+            "type": "string",
+            "required": false,
+            "description": "Merge method",
+            "enum": [
+              "merge",
+              "squash",
+              "rebase"
+            ],
+            "source_path": "inputSchema.properties.merge_method"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "pull_number",
+            "original_name": "pullNumber",
+            "type": "number",
+            "required": true,
+            "description": "Pull request number",
+            "source_path": "inputSchema.properties.pullNumber"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          }
+        ],
+        "maps_to": "tool:merge_pull_request",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "pull_request_read",
+        "operation_name": "pull_request_read",
+        "title": "Get details for a single pull request",
+        "description": "Get information on a specific pull request in GitHub repository.",
+        "endpoint": "READ",
+        "endpoint_confidence": "high",
+        "danger_level": "safe",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "method",
+            "original_name": "method",
+            "type": "string",
+            "required": true,
+            "description": "Action to specify what pull request data needs to be retrieved from GitHub. \nPossible options: \n 1. get - Get details of a specific pull request.\n 2. get_diff - Get the diff of a pull request.\n 3. get_status - Get combined commit status of a head commit in a pull request.\n 4. get_files - Get the list of files changed in a pull request. Use with pagination parameters to control the number of results returned.\n 5. get_review_comments - Get review threads on a pull request. Each thread contains logically grouped review comments made on the same code location during pull request reviews. Returns threads with metadata (isResolved, isOutdated, isCollapsed) and their associated comments. Use cursor-based pagination (perPage, after) to control results.\n 6. get_reviews - Get the reviews on a pull request. When asked for review comments, use get_review_comments method.\n 7. get_comments - Get comments on a pull request. Use this if user doesn't specifically want review comments. Use with pagination parameters to control the number of results returned.\n 8. get_check_runs - Get check runs for the head commit of a pull request. Check runs are the individual CI/CD jobs and checks that run on the PR.\n",
+            "enum": [
+              "get",
+              "get_diff",
+              "get_status",
+              "get_files",
+              "get_review_comments",
+              "get_reviews",
+              "get_comments",
+              "get_check_runs"
+            ],
+            "source_path": "inputSchema.properties.method"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "page",
+            "original_name": "page",
+            "type": "number",
+            "required": false,
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1,
+            "source_path": "inputSchema.properties.page"
+          },
+          {
+            "name": "per_page",
+            "original_name": "perPage",
+            "type": "number",
+            "required": false,
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100,
+            "source_path": "inputSchema.properties.perPage"
+          },
+          {
+            "name": "pull_number",
+            "original_name": "pullNumber",
+            "type": "number",
+            "required": true,
+            "description": "Pull request number",
+            "source_path": "inputSchema.properties.pullNumber"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          }
+        ],
+        "maps_to": "tool:pull_request_read",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "readOnlyHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "pull_request_review_write",
+        "operation_name": "pull_request_review_write",
+        "title": "Write operations (create, submit, delete) on pull request reviews.",
+        "description": "Create and/or submit, delete review of a pull request.\n\nAvailable methods:\n- create: Create a new review of a pull request. If \"event\" parameter is provided, the review is submitted. If \"event\" is omitted, a pending review is created.\n- submit_pending: Submit an existing pending review of a pull request. This requires that a pending review exists for the current user on the specified pull request. The \"body\" and \"event\" parameters are used when submitting the review.\n- delete_pending: Delete an existing pending review of a pull request. This requires that a pending review exists for the current user on the specified pull request.\n",
+        "endpoint": "UPDATE",
+        "endpoint_confidence": "medium",
+        "danger_level": "reversible",
+        "needs_review": true,
+        "review_reasons": [
+          "Write suffix is semantically broad and may hide create/update behavior."
+        ],
+        "params": [
+          {
+            "name": "body",
+            "original_name": "body",
+            "type": "string",
+            "required": false,
+            "description": "Review comment text",
+            "source_path": "inputSchema.properties.body"
+          },
+          {
+            "name": "commit_id",
+            "original_name": "commitID",
+            "type": "string",
+            "required": false,
+            "description": "SHA of commit to review",
+            "source_path": "inputSchema.properties.commitID"
+          },
+          {
+            "name": "event",
+            "original_name": "event",
+            "type": "string",
+            "required": false,
+            "description": "Review action to perform.",
+            "enum": [
+              "APPROVE",
+              "REQUEST_CHANGES",
+              "COMMENT"
+            ],
+            "source_path": "inputSchema.properties.event"
+          },
+          {
+            "name": "method",
+            "original_name": "method",
+            "type": "string",
+            "required": true,
+            "description": "The write operation to perform on pull request review.",
+            "enum": [
+              "create",
+              "submit_pending",
+              "delete_pending"
+            ],
+            "source_path": "inputSchema.properties.method"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "pull_number",
+            "original_name": "pullNumber",
+            "type": "number",
+            "required": true,
+            "description": "Pull request number",
+            "source_path": "inputSchema.properties.pullNumber"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          }
+        ],
+        "maps_to": "tool:pull_request_review_write",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "push_files",
+        "operation_name": "push_files",
+        "title": "Push files to repository",
+        "description": "Push multiple files to a GitHub repository in a single commit",
+        "endpoint": "EXECUTE",
+        "endpoint_confidence": "medium",
+        "danger_level": "dangerous",
+        "needs_review": true,
+        "review_reasons": [
+          "Action-oriented tool classified as EXECUTE conservatively."
+        ],
+        "params": [
+          {
+            "name": "branch",
+            "original_name": "branch",
+            "type": "string",
+            "required": true,
+            "description": "Branch to push to",
+            "source_path": "inputSchema.properties.branch"
+          },
+          {
+            "name": "files",
+            "original_name": "files",
+            "type": "array",
+            "required": true,
+            "description": "Array of file objects to push, each object with path (string) and content (string)",
+            "source_path": "inputSchema.properties.files"
+          },
+          {
+            "name": "message",
+            "original_name": "message",
+            "type": "string",
+            "required": true,
+            "description": "Commit message",
+            "source_path": "inputSchema.properties.message"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          }
+        ],
+        "maps_to": "tool:push_files",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "request_copilot_review",
+        "operation_name": "request_copilot_review",
+        "title": "Request Copilot review",
+        "description": "Request a GitHub Copilot code review for a pull request. Use this for automated feedback on pull requests, usually before requesting a human reviewer.",
+        "endpoint": "EXECUTE",
+        "endpoint_confidence": "medium",
+        "danger_level": "dangerous",
+        "needs_review": true,
+        "review_reasons": [
+          "Action-oriented tool classified as EXECUTE conservatively."
+        ],
+        "params": [
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "pull_number",
+            "original_name": "pullNumber",
+            "type": "number",
+            "required": true,
+            "description": "Pull request number",
+            "source_path": "inputSchema.properties.pullNumber"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          }
+        ],
+        "maps_to": "tool:request_copilot_review",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "search_code",
+        "operation_name": "search_code",
+        "title": "Search code",
+        "description": "Fast and precise code search across ALL GitHub repositories using GitHub's native search engine. Best for finding exact symbols, functions, classes, or specific code patterns.",
+        "endpoint": "READ",
+        "endpoint_confidence": "high",
+        "danger_level": "safe",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "order",
+            "original_name": "order",
+            "type": "string",
+            "required": false,
+            "description": "Sort order for results",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "source_path": "inputSchema.properties.order"
+          },
+          {
+            "name": "page",
+            "original_name": "page",
+            "type": "number",
+            "required": false,
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1,
+            "source_path": "inputSchema.properties.page"
+          },
+          {
+            "name": "per_page",
+            "original_name": "perPage",
+            "type": "number",
+            "required": false,
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100,
+            "source_path": "inputSchema.properties.perPage"
+          },
+          {
+            "name": "query",
+            "original_name": "query",
+            "type": "string",
+            "required": true,
+            "description": "Search query using GitHub's powerful code search syntax. Examples: 'content:Skill language:Java org:github', 'NOT is:archived language:Python OR language:go', 'repo:github/github-mcp-server'. Supports exact matching, language filters, path filters, and more.",
+            "source_path": "inputSchema.properties.query"
+          },
+          {
+            "name": "sort",
+            "original_name": "sort",
+            "type": "string",
+            "required": false,
+            "description": "Sort field ('indexed' only)",
+            "source_path": "inputSchema.properties.sort"
+          }
+        ],
+        "maps_to": "tool:search_code",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "readOnlyHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "search_issues",
+        "operation_name": "search_issues",
+        "title": "Search issues",
+        "description": "Search for issues in GitHub repositories using issues search syntax already scoped to is:issue",
+        "endpoint": "READ",
+        "endpoint_confidence": "high",
+        "danger_level": "safe",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "order",
+            "original_name": "order",
+            "type": "string",
+            "required": false,
+            "description": "Sort order",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "source_path": "inputSchema.properties.order"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": false,
+            "description": "Optional repository owner. If provided with repo, only issues for this repository are listed.",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "page",
+            "original_name": "page",
+            "type": "number",
+            "required": false,
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1,
+            "source_path": "inputSchema.properties.page"
+          },
+          {
+            "name": "per_page",
+            "original_name": "perPage",
+            "type": "number",
+            "required": false,
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100,
+            "source_path": "inputSchema.properties.perPage"
+          },
+          {
+            "name": "query",
+            "original_name": "query",
+            "type": "string",
+            "required": true,
+            "description": "Search query using GitHub issues search syntax",
+            "source_path": "inputSchema.properties.query"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": false,
+            "description": "Optional repository name. If provided with owner, only issues for this repository are listed.",
+            "source_path": "inputSchema.properties.repo"
+          },
+          {
+            "name": "sort",
+            "original_name": "sort",
+            "type": "string",
+            "required": false,
+            "description": "Sort field by number of matches of categories, defaults to best match",
+            "enum": [
+              "comments",
+              "reactions",
+              "reactions-+1",
+              "reactions--1",
+              "reactions-smile",
+              "reactions-thinking_face",
+              "reactions-heart",
+              "reactions-tada",
+              "interactions",
+              "created",
+              "updated"
+            ],
+            "source_path": "inputSchema.properties.sort"
+          }
+        ],
+        "maps_to": "tool:search_issues",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "readOnlyHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "search_pull_requests",
+        "operation_name": "search_pull_requests",
+        "title": "Search pull requests",
+        "description": "Search for pull requests in GitHub repositories using issues search syntax already scoped to is:pr",
+        "endpoint": "READ",
+        "endpoint_confidence": "high",
+        "danger_level": "safe",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "order",
+            "original_name": "order",
+            "type": "string",
+            "required": false,
+            "description": "Sort order",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "source_path": "inputSchema.properties.order"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": false,
+            "description": "Optional repository owner. If provided with repo, only pull requests for this repository are listed.",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "page",
+            "original_name": "page",
+            "type": "number",
+            "required": false,
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1,
+            "source_path": "inputSchema.properties.page"
+          },
+          {
+            "name": "per_page",
+            "original_name": "perPage",
+            "type": "number",
+            "required": false,
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100,
+            "source_path": "inputSchema.properties.perPage"
+          },
+          {
+            "name": "query",
+            "original_name": "query",
+            "type": "string",
+            "required": true,
+            "description": "Search query using GitHub pull request search syntax",
+            "source_path": "inputSchema.properties.query"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": false,
+            "description": "Optional repository name. If provided with owner, only pull requests for this repository are listed.",
+            "source_path": "inputSchema.properties.repo"
+          },
+          {
+            "name": "sort",
+            "original_name": "sort",
+            "type": "string",
+            "required": false,
+            "description": "Sort field by number of matches of categories, defaults to best match",
+            "enum": [
+              "comments",
+              "reactions",
+              "reactions-+1",
+              "reactions--1",
+              "reactions-smile",
+              "reactions-thinking_face",
+              "reactions-heart",
+              "reactions-tada",
+              "interactions",
+              "created",
+              "updated"
+            ],
+            "source_path": "inputSchema.properties.sort"
+          }
+        ],
+        "maps_to": "tool:search_pull_requests",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "readOnlyHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "search_repositories",
+        "operation_name": "search_repositories",
+        "title": "Search repositories",
+        "description": "Find GitHub repositories by name, description, readme, topics, or other metadata. Perfect for discovering projects, finding examples, or locating specific repositories across GitHub.",
+        "endpoint": "READ",
+        "endpoint_confidence": "high",
+        "danger_level": "safe",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "minimal_output",
+            "original_name": "minimal_output",
+            "type": "boolean",
+            "required": false,
+            "description": "Return minimal repository information (default: true). When false, returns full GitHub API repository objects.",
+            "default": true,
+            "source_path": "inputSchema.properties.minimal_output"
+          },
+          {
+            "name": "order",
+            "original_name": "order",
+            "type": "string",
+            "required": false,
+            "description": "Sort order",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "source_path": "inputSchema.properties.order"
+          },
+          {
+            "name": "page",
+            "original_name": "page",
+            "type": "number",
+            "required": false,
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1,
+            "source_path": "inputSchema.properties.page"
+          },
+          {
+            "name": "per_page",
+            "original_name": "perPage",
+            "type": "number",
+            "required": false,
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100,
+            "source_path": "inputSchema.properties.perPage"
+          },
+          {
+            "name": "query",
+            "original_name": "query",
+            "type": "string",
+            "required": true,
+            "description": "Repository search query. Examples: 'machine learning in:name stars:>1000 language:python', 'topic:react', 'user:facebook'. Supports advanced search syntax for precise filtering.",
+            "source_path": "inputSchema.properties.query"
+          },
+          {
+            "name": "sort",
+            "original_name": "sort",
+            "type": "string",
+            "required": false,
+            "description": "Sort repositories by field, defaults to best match",
+            "enum": [
+              "stars",
+              "forks",
+              "help-wanted-issues",
+              "updated"
+            ],
+            "source_path": "inputSchema.properties.sort"
+          }
+        ],
+        "maps_to": "tool:search_repositories",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "readOnlyHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "search_users",
+        "operation_name": "search_users",
+        "title": "Search users",
+        "description": "Find GitHub users by username, real name, or other profile information. Useful for locating developers, contributors, or team members.",
+        "endpoint": "READ",
+        "endpoint_confidence": "high",
+        "danger_level": "safe",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "order",
+            "original_name": "order",
+            "type": "string",
+            "required": false,
+            "description": "Sort order",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "source_path": "inputSchema.properties.order"
+          },
+          {
+            "name": "page",
+            "original_name": "page",
+            "type": "number",
+            "required": false,
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1,
+            "source_path": "inputSchema.properties.page"
+          },
+          {
+            "name": "per_page",
+            "original_name": "perPage",
+            "type": "number",
+            "required": false,
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100,
+            "source_path": "inputSchema.properties.perPage"
+          },
+          {
+            "name": "query",
+            "original_name": "query",
+            "type": "string",
+            "required": true,
+            "description": "User search query. Examples: 'john smith', 'location:seattle', 'followers:>100'. Search is automatically scoped to type:user.",
+            "source_path": "inputSchema.properties.query"
+          },
+          {
+            "name": "sort",
+            "original_name": "sort",
+            "type": "string",
+            "required": false,
+            "description": "Sort users by number of followers or repositories, or when the person joined GitHub.",
+            "enum": [
+              "followers",
+              "repositories",
+              "joined"
+            ],
+            "source_path": "inputSchema.properties.sort"
+          }
+        ],
+        "maps_to": "tool:search_users",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title",
+            "readOnlyHint"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "sub_issue_write",
+        "operation_name": "sub_issue_write",
+        "title": "Change sub-issue",
+        "description": "Add a sub-issue to a parent issue in a GitHub repository.",
+        "endpoint": "UPDATE",
+        "endpoint_confidence": "medium",
+        "danger_level": "reversible",
+        "needs_review": true,
+        "review_reasons": [
+          "Write suffix is semantically broad and may hide create/update behavior."
+        ],
+        "params": [
+          {
+            "name": "after_id",
+            "original_name": "after_id",
+            "type": "number",
+            "required": false,
+            "description": "The ID of the sub-issue to be prioritized after (either after_id OR before_id should be specified)",
+            "source_path": "inputSchema.properties.after_id"
+          },
+          {
+            "name": "before_id",
+            "original_name": "before_id",
+            "type": "number",
+            "required": false,
+            "description": "The ID of the sub-issue to be prioritized before (either after_id OR before_id should be specified)",
+            "source_path": "inputSchema.properties.before_id"
+          },
+          {
+            "name": "issue_number",
+            "original_name": "issue_number",
+            "type": "number",
+            "required": true,
+            "description": "The number of the parent issue",
+            "source_path": "inputSchema.properties.issue_number"
+          },
+          {
+            "name": "method",
+            "original_name": "method",
+            "type": "string",
+            "required": true,
+            "description": "The action to perform on a single sub-issue\nOptions are:\n- 'add' - add a sub-issue to a parent issue in a GitHub repository.\n- 'remove' - remove a sub-issue from a parent issue in a GitHub repository.\n- 'reprioritize' - change the order of sub-issues within a parent issue in a GitHub repository. Use either 'after_id' or 'before_id' to specify the new position.\n\t\t\t\t",
+            "source_path": "inputSchema.properties.method"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "replace_parent",
+            "original_name": "replace_parent",
+            "type": "boolean",
+            "required": false,
+            "description": "When true, replaces the sub-issue's current parent issue. Use with 'add' method only.",
+            "source_path": "inputSchema.properties.replace_parent"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          },
+          {
+            "name": "sub_issue_id",
+            "original_name": "sub_issue_id",
+            "type": "number",
+            "required": true,
+            "description": "The ID of the sub-issue to add. ID is not the same as issue number",
+            "source_path": "inputSchema.properties.sub_issue_id"
+          }
+        ],
+        "maps_to": "tool:sub_issue_write",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "update_pull_request",
+        "operation_name": "update_pull_request",
+        "title": "Edit pull request",
+        "description": "Update an existing pull request in a GitHub repository.",
+        "endpoint": "UPDATE",
+        "endpoint_confidence": "high",
+        "danger_level": "reversible",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "base",
+            "original_name": "base",
+            "type": "string",
+            "required": false,
+            "description": "New base branch name",
+            "source_path": "inputSchema.properties.base"
+          },
+          {
+            "name": "body",
+            "original_name": "body",
+            "type": "string",
+            "required": false,
+            "description": "New description",
+            "source_path": "inputSchema.properties.body"
+          },
+          {
+            "name": "draft",
+            "original_name": "draft",
+            "type": "boolean",
+            "required": false,
+            "description": "Mark pull request as draft (true) or ready for review (false)",
+            "source_path": "inputSchema.properties.draft"
+          },
+          {
+            "name": "maintainer_can_modify",
+            "original_name": "maintainer_can_modify",
+            "type": "boolean",
+            "required": false,
+            "description": "Allow maintainer edits",
+            "source_path": "inputSchema.properties.maintainer_can_modify"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "pull_number",
+            "original_name": "pullNumber",
+            "type": "number",
+            "required": true,
+            "description": "Pull request number to update",
+            "source_path": "inputSchema.properties.pullNumber"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          },
+          {
+            "name": "reviewers",
+            "original_name": "reviewers",
+            "type": "array",
+            "required": false,
+            "description": "GitHub usernames to request reviews from",
+            "source_path": "inputSchema.properties.reviewers"
+          },
+          {
+            "name": "state",
+            "original_name": "state",
+            "type": "string",
+            "required": false,
+            "description": "New state",
+            "enum": [
+              "open",
+              "closed"
+            ],
+            "source_path": "inputSchema.properties.state"
+          },
+          {
+            "name": "title",
+            "original_name": "title",
+            "type": "string",
+            "required": false,
+            "description": "New title",
+            "source_path": "inputSchema.properties.title"
+          }
+        ],
+        "maps_to": "tool:update_pull_request",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title"
+          ],
+          "input_schema_present": true
+        }
+      },
+      {
+        "source_tool_name": "update_pull_request_branch",
+        "operation_name": "update_pull_request_branch",
+        "title": "Update pull request branch",
+        "description": "Update the branch of a pull request with the latest changes from the base branch.",
+        "endpoint": "UPDATE",
+        "endpoint_confidence": "high",
+        "danger_level": "reversible",
+        "needs_review": false,
+        "review_reasons": [],
+        "params": [
+          {
+            "name": "expected_head_sha",
+            "original_name": "expectedHeadSha",
+            "type": "string",
+            "required": false,
+            "description": "The expected SHA of the pull request's HEAD ref",
+            "source_path": "inputSchema.properties.expectedHeadSha"
+          },
+          {
+            "name": "owner",
+            "original_name": "owner",
+            "type": "string",
+            "required": true,
+            "description": "Repository owner",
+            "source_path": "inputSchema.properties.owner"
+          },
+          {
+            "name": "pull_number",
+            "original_name": "pullNumber",
+            "type": "number",
+            "required": true,
+            "description": "Pull request number",
+            "source_path": "inputSchema.properties.pullNumber"
+          },
+          {
+            "name": "repo",
+            "original_name": "repo",
+            "type": "string",
+            "required": true,
+            "description": "Repository name",
+            "source_path": "inputSchema.properties.repo"
+          }
+        ],
+        "maps_to": "tool:update_pull_request_branch",
+        "returns": {
+          "type": "object",
+          "name": "WrappedToolResult",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "provenance": {
+          "name": "name",
+          "description": "description",
+          "annotations": [
+            "title"
+          ],
+          "input_schema_present": true
+        }
+      }
+    ],
+    "warnings": [
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'pullNumber' was normalized to 'pull_number'.",
+        "tool": "add_comment_to_pending_review",
+        "field": "pullNumber",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'startLine' was normalized to 'start_line'.",
+        "tool": "add_comment_to_pending_review",
+        "field": "startLine",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'startSide' was normalized to 'start_side'.",
+        "tool": "add_comment_to_pending_review",
+        "field": "startSide",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'subjectType' was normalized to 'subject_type'.",
+        "tool": "add_comment_to_pending_review",
+        "field": "subjectType",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'commentId' was normalized to 'comment_id'.",
+        "tool": "add_reply_to_pull_request_comment",
+        "field": "commentId",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'pullNumber' was normalized to 'pull_number'.",
+        "tool": "add_reply_to_pull_request_comment",
+        "field": "pullNumber",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "REVIEW_REQUIRED",
+        "severity": "warning",
+        "message": "Tool name spans both create and update semantics.",
+        "tool": "create_or_update_file",
+        "heuristic": "endpoint_classification"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'autoInit' was normalized to 'auto_init'.",
+        "tool": "create_repository",
+        "field": "autoInit",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'perPage' was normalized to 'per_page'.",
+        "tool": "get_commit",
+        "field": "perPage",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'perPage' was normalized to 'per_page'.",
+        "tool": "issue_read",
+        "field": "perPage",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "REVIEW_REQUIRED",
+        "severity": "info",
+        "message": "Write suffix is semantically broad and may hide create/update behavior.",
+        "tool": "issue_write",
+        "heuristic": "endpoint_classification"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'perPage' was normalized to 'per_page'.",
+        "tool": "list_branches",
+        "field": "perPage",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'perPage' was normalized to 'per_page'.",
+        "tool": "list_commits",
+        "field": "perPage",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'orderBy' was normalized to 'order_by'.",
+        "tool": "list_issues",
+        "field": "orderBy",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'perPage' was normalized to 'per_page'.",
+        "tool": "list_issues",
+        "field": "perPage",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'perPage' was normalized to 'per_page'.",
+        "tool": "list_pull_requests",
+        "field": "perPage",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'perPage' was normalized to 'per_page'.",
+        "tool": "list_releases",
+        "field": "perPage",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'perPage' was normalized to 'per_page'.",
+        "tool": "list_tags",
+        "field": "perPage",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "REVIEW_REQUIRED",
+        "severity": "info",
+        "message": "Action-oriented tool classified as EXECUTE conservatively.",
+        "tool": "merge_pull_request",
+        "heuristic": "endpoint_classification"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'pullNumber' was normalized to 'pull_number'.",
+        "tool": "merge_pull_request",
+        "field": "pullNumber",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'perPage' was normalized to 'per_page'.",
+        "tool": "pull_request_read",
+        "field": "perPage",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'pullNumber' was normalized to 'pull_number'.",
+        "tool": "pull_request_read",
+        "field": "pullNumber",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "REVIEW_REQUIRED",
+        "severity": "info",
+        "message": "Write suffix is semantically broad and may hide create/update behavior.",
+        "tool": "pull_request_review_write",
+        "heuristic": "endpoint_classification"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'commitID' was normalized to 'commit_id'.",
+        "tool": "pull_request_review_write",
+        "field": "commitID",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'pullNumber' was normalized to 'pull_number'.",
+        "tool": "pull_request_review_write",
+        "field": "pullNumber",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "REVIEW_REQUIRED",
+        "severity": "info",
+        "message": "Action-oriented tool classified as EXECUTE conservatively.",
+        "tool": "push_files",
+        "heuristic": "endpoint_classification"
+      },
+      {
+        "code": "REVIEW_REQUIRED",
+        "severity": "info",
+        "message": "Action-oriented tool classified as EXECUTE conservatively.",
+        "tool": "request_copilot_review",
+        "heuristic": "endpoint_classification"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'pullNumber' was normalized to 'pull_number'.",
+        "tool": "request_copilot_review",
+        "field": "pullNumber",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'perPage' was normalized to 'per_page'.",
+        "tool": "search_code",
+        "field": "perPage",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'perPage' was normalized to 'per_page'.",
+        "tool": "search_issues",
+        "field": "perPage",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'perPage' was normalized to 'per_page'.",
+        "tool": "search_pull_requests",
+        "field": "perPage",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'perPage' was normalized to 'per_page'.",
+        "tool": "search_repositories",
+        "field": "perPage",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'perPage' was normalized to 'per_page'.",
+        "tool": "search_users",
+        "field": "perPage",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "REVIEW_REQUIRED",
+        "severity": "info",
+        "message": "Write suffix is semantically broad and may hide create/update behavior.",
+        "tool": "sub_issue_write",
+        "heuristic": "endpoint_classification"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'pullNumber' was normalized to 'pull_number'.",
+        "tool": "update_pull_request",
+        "field": "pullNumber",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'expectedHeadSha' was normalized to 'expected_head_sha'.",
+        "tool": "update_pull_request_branch",
+        "field": "expectedHeadSha",
+        "heuristic": "snake_case_normalization"
+      },
+      {
+        "code": "PARAM_NAME_NORMALIZED",
+        "severity": "info",
+        "message": "Parameter 'pullNumber' was normalized to 'pull_number'.",
+        "tool": "update_pull_request_branch",
+        "field": "pullNumber",
+        "heuristic": "snake_case_normalization"
+      }
+    ]
+  }
+}

--- a/generated/github-mcp/capture/discovery-bundle.json
+++ b/generated/github-mcp/capture/discovery-bundle.json
@@ -1,10 +1,10 @@
 {
-  "schema_version": "1.0",
+  "schema_version": "1.0.0-draft",
   "source": {
     "name": "github-mcp-remote",
     "server_url": "https://api.githubcopilot.com/mcp/",
     "transport": "streamable_http",
-    "captured_at": "2026-03-13T18:59:59.456Z",
+    "captured_at": "2026-03-13T20:08:48.081Z",
     "server": {
       "name": "github-mcp-server",
       "version": "github-mcp-server/remote-9f836f5fe414b6a085717f480c7f23093404340d",
@@ -2527,7 +2527,14 @@
           "annotations": [
             "title"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -2586,7 +2593,14 @@
           "annotations": [
             "title"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -2653,7 +2667,14 @@
           "annotations": [
             "title"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -2721,7 +2742,14 @@
             "title",
             "idempotentHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -2780,7 +2808,14 @@
           "annotations": [
             "title"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -2865,7 +2900,14 @@
           "annotations": [
             "title"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -2956,7 +2998,14 @@
           "annotations": [
             "title"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -3024,7 +3073,14 @@
             "title",
             "openWorldHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -3091,7 +3147,14 @@
           "annotations": [
             "title"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -3159,7 +3222,14 @@
             "title",
             "destructiveHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -3210,7 +3280,14 @@
           "annotations": [
             "title"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -3290,7 +3367,14 @@
             "title",
             "readOnlyHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -3343,7 +3427,14 @@
             "readOnlyHint",
             "openWorldHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -3412,7 +3503,14 @@
             "title",
             "readOnlyHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -3464,7 +3562,14 @@
             "title",
             "readOnlyHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -3508,7 +3613,14 @@
             "title",
             "readOnlyHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -3535,7 +3647,14 @@
             "title",
             "readOnlyHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -3587,7 +3706,14 @@
             "title",
             "readOnlyHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -3639,7 +3765,14 @@
             "title",
             "readOnlyHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -3683,7 +3816,14 @@
             "title",
             "readOnlyHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -3719,7 +3859,14 @@
             "title",
             "readOnlyHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -3804,7 +3951,14 @@
             "title",
             "readOnlyHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -3950,7 +4104,14 @@
           "annotations": [
             "title"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -4013,7 +4174,14 @@
             "title",
             "readOnlyHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -4092,7 +4260,14 @@
             "title",
             "readOnlyHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -4128,7 +4303,14 @@
             "title",
             "readOnlyHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -4243,7 +4425,14 @@
             "title",
             "readOnlyHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -4361,7 +4550,14 @@
             "title",
             "readOnlyHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -4424,7 +4620,14 @@
             "title",
             "readOnlyHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -4487,7 +4690,14 @@
             "title",
             "readOnlyHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -4569,7 +4779,14 @@
           "annotations": [
             "title"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -4658,7 +4875,14 @@
             "title",
             "readOnlyHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -4753,7 +4977,14 @@
           "annotations": [
             "title"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -4822,7 +5053,14 @@
           "annotations": [
             "title"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -4875,7 +5113,14 @@
           "annotations": [
             "title"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -4950,7 +5195,14 @@
             "title",
             "readOnlyHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -5054,7 +5306,14 @@
             "title",
             "readOnlyHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -5158,7 +5417,14 @@
             "title",
             "readOnlyHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -5248,7 +5514,14 @@
             "title",
             "readOnlyHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -5328,7 +5601,14 @@
             "title",
             "readOnlyHint"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -5421,7 +5701,14 @@
           "annotations": [
             "title"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -5532,7 +5819,14 @@
           "annotations": [
             "title"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       },
       {
@@ -5591,7 +5885,14 @@
           "annotations": [
             "title"
           ],
-          "input_schema_present": true
+          "input_schema_present": true,
+          "inference_sources": {
+            "operation_name": "direct_source_metadata",
+            "description": "direct_source_metadata",
+            "endpoint": "heuristic_classification",
+            "danger_level": "heuristic_classification",
+            "maps_to": "deterministic_normalization"
+          }
         }
       }
     ],

--- a/generated/github-mcp/capture/raw-tools-list.json
+++ b/generated/github-mcp/capture/raw-tools-list.json
@@ -1,0 +1,2377 @@
+[
+  {
+    "name": "add_comment_to_pending_review",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACwUlEQVRIie2Vz28UZRjHP993pi0QIC3YahNjirtmd3bS3Q1eUHvQEPUiEv8A4kXjwRJ78MCFBLjBBRKCHowHE38cNCbGGx6IUoKiodtNpoNmTJp4oSJNQ3pw29l5POxus2wo3QTwxPc0887zfD7zvu9kXnjEUfdNrjj5vJOmMP4e9JrfR1G02tuQD8tvgpck0dxCPwK30ViqnJTcr4bOmfRlI/PrhUJ5313woDpDpu8ss7f6nYHrvDnGcYlPsoY/bKaXwHY3HWfvgmNnMX0zvMM7069A3c3pkEYWa7UVgFxQPSfs7SSeH3k2rEy5jMubMBoG1yQ+SBbm53of+gCybMkk/H8VAFdbZisZLAFsJ11oyL+BUURcwrjWAZixXeIwxs/5UuVAr0QAYRjubGR+HWy3mb6QCIBXQe8nce0jgIkwfMo3/xLG085x8I9ofkMyUa0O+w2rgS0mcf3lboEDiKJo1cvsIDDr4D1DhTb8407hYhTdTJW+AvrdMnuhG9Je1m9BBzbfjXbyQcXypeqJLQt7+0rVE/mgYr3j7l7FDzOPBY8FDx6vc1EolPeNjI5/Jpgw7Lm9o+Pry//c/K0PhnLFyrSMDxE79jwxvn9079gvt28vrUD7V1EoFHalbltd2C7DfS4sAF4DTSdx7cL96LliZVriPPADuL+geRh0Z8il5SiKVn2ATENvCCYw78U/b8xdBcgHlYuGHQXuK5A4ClxM4vnXW8Lqp5JdWWt6h4CvWnsgxgDSbRZ3Gg0tCJ7sY4nGwDZOt/WBZtzN9FswLgM2sGann5mcPDaw5pWEHQH7cUu86SdkR3LF6tfrA814MNVpwNrM1leUxPXrSKfMeHcwdctyNotY8c3NbMX3LJsB3ZHsymDqlkHvYHYyievXWxPpSj4o75eYIuPWZof+vRKG4c61pncIx6gZsx34/5L/ACy3ElqUYhuvAAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABn0lEQVRIie2Vvy5EURDGvyMUkhUU/pS2Q2clwvIKqL0Cm9ArrBcQShJPoLFR2YaIhIjQ7a7E39IiCgqVn8KsPY697E3oTHPumTPf990z986M9Mfm/A0wKGlMUlnSlnPuOQQAE5LOnXOFWErAIvBK1S6BZBAzZ2fzcckHjXwVaAXSwD2wWYN8A2iKK1ABt3m+ZeDRnseIthdgDxioxd1o662tfZIO7Lnf8xcklST1StqRdORxNEualHQIDDvnTmvdIGE5vwdWgLy93bQX0w0UgSdgKMC3AdfA7ndpSgKbduUbYBoI/7Ju4BiYrYFfAl4iBbxAgOyPgV9xWYDQ3xCXKK79C/wL/KJZoeW8QpsJCy0C54AMULaGmQu7sIAW4MpaxTKwbQU3U4dAxmLzwLpxXAIJP2jKgkY8Xx4o1SFwBmx7+7RxTUnVb9Bpa9HDFiR1/SRgWH+6FT3/h2qK6sBpB0aBB7yB880NcpaWtGHXjCsVBmb5PDIvgJ46BJKW84q9AguV87Adp/Q+9O8UMfQjRBKSxiV1SNp3zp3Ug/sVewPruexhKwhGXQAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Add review comment to the requester's latest pending pull request review. A pending review needs to already exist to call this (check with the user if not sure).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "body": {
+          "type": "string",
+          "description": "The text of the review comment"
+        },
+        "line": {
+          "type": "number",
+          "description": "The line of the blob in the pull request diff that the comment applies to. For multi-line comments, the last line of the range"
+        },
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "path": {
+          "type": "string",
+          "description": "The relative path to the file that necessitates a comment"
+        },
+        "pullNumber": {
+          "type": "number",
+          "description": "Pull request number"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        },
+        "side": {
+          "type": "string",
+          "description": "The side of the diff to comment on. LEFT indicates the previous state, RIGHT indicates the new state",
+          "enum": [
+            "LEFT",
+            "RIGHT"
+          ]
+        },
+        "startLine": {
+          "type": "number",
+          "description": "For multi-line comments, the first line of the range that the comment applies to"
+        },
+        "startSide": {
+          "type": "string",
+          "description": "For multi-line comments, the starting side of the diff that the comment applies to. LEFT indicates the previous state, RIGHT indicates the new state",
+          "enum": [
+            "LEFT",
+            "RIGHT"
+          ]
+        },
+        "subjectType": {
+          "type": "string",
+          "description": "The level at which the comment is targeted",
+          "enum": [
+            "FILE",
+            "LINE"
+          ]
+        }
+      },
+      "required": [
+        "owner",
+        "repo",
+        "pullNumber",
+        "path",
+        "body",
+        "subjectType"
+      ]
+    },
+    "annotations": {
+      "title": "Add review comment to the requester's latest pending pull request review"
+    }
+  },
+  {
+    "name": "add_issue_comment",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAC2UlEQVRIicWVMUyTaRjHf/+vVUpOJOdilOYoUvVreq2CDmLOwdlAS5xMbrrhBifjYG7QjYuJw108nZx1huLgYlw0QshxChUK2koxHHcuCmgsFfieG0or3kGPSoz/8X3f5/97nvfN8z7wmaVqm9FodFfR/EnMugy5giCAwYwgI9Ff9Hl9L9Lp1zUBgsGO+rqGwnlhF4CdwBSyAUwvS1G220zHBSFgHtmVxYWvfp2ZGSj8LyAcjgfZphTQZtAr7OdsZvSP9RIJR+LtQhcNusF+d1aUfPp05M8NAavmg8AOk3cmN56+s1Hpa7U/cviUYbcw3jgex9ZCKoBgsKM+0PDuAdBq2He5zOiTzZiXtc+NxRw598GeLRcWTuTz+UUAp3ygrqFwHmgzeWdqNQd4PpFOy/gedNQfaDz3UQXRaHRX0fNPGdzNZUZO12q+VuHIoV7g5Hu/1/IinX7tABTNnwR2SvRsxRzAzOsBGuuWfAkoX5FZFzCVHR95tFVAbiI9DEwj6wLwl5YVMTRYLTDsxjuRrgGYYz/kxkbvbXRWMOBB24cKYI9ks1X8hXQDaAaa5XG9WjImZgV71wI+m8qAv8y0t1pSmP0ITANTmHO2qqvRZDALlTdgHKyjWkx2YvQ2cHtTacMxYBhWK5DoF4TCkXj7Jg02VKsbOwI0Y+qvALZrOQXMC13cKkDSJWBuJUCqAhgbG3uF7IpBcn/k8KlPNQ+78U5QQuhy/vHjuQoAYPndwi9gw4bd2ufGYrWatxz8No50ExhaKsz9Vl6vAPL5/KKzoiTGG0fOg1oqCbvxTp/juw/M+zynu/yTwjoD58CBQ02ez/pAR4E+M69ntf3/o1Y3dqR050oAQz7P6Z6cfPRRw647MkOhUMAfaDyH+AloBKYNPRT292rQHoMOSp09J3TZlt5ezWazxX97VR3638RiX9ct+RImSyBcrDT0ETMyMp4ptRIgVX7QL6J/ALSUEwJ5rdg2AAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABxElEQVRIibWVvW4TURCFv0vlNEDcIHAkKAERJOIKSjoUArwBPwUFFaKIIngAJARCPIgdh4cgRBYt6ZIAEYEqdhpEw0fhCbkKa68dxyNtsfNzzpnZu3NhwpYGBdUqcA+4A1wEZiK0DawD74FWSml3JAJ1CngGLAIngU1gFfgZKWeAG8AFoAu8At6mlH6VtqTOqJ/UP2pDnRuQO6c27VlbrQ0Dvq121Fulag7q5qPmW18SdSqUd9Qrw4Jn9bNR21YrRQkvYixDKy/AuB3jWjocqKpdtXFU8AxrOTqZzp2PgvnaMRDUA+tB7mypG+OCZ3hbahPgRPguAR9LihaicEu9WcKxClzOi/fU1wPAk7rjgX0uEfNG3cs7mJjtE+wA5/olpZQEHgNf6K2NJyW4NeD7v7c4WptjSc0svlMjdzyM2fbdOyOA7x/T+7mzGj9H8xgIWuquevpw4HmsivkxwBdC/WJRsBKLqqPOHgH8aqybtcJlF0m1WLndUToJ5V31q9r3NOYk7Wh1Wa0PyK3HzA3l/4H3uzIrwFNgCThF7/x/AH5EylngOnAe6AAvgXcppd9DEWRE08DdeIou/RVgJaXUGYQzUfsL+zmwV7BtIq0AAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Add a comment to a specific issue in a GitHub repository. Use this tool to add comments to pull requests as well (in this case pass pull request number as issue_number), but only if user is not asking specifically to add review comments.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "body": {
+          "type": "string",
+          "description": "Comment content"
+        },
+        "issue_number": {
+          "type": "number",
+          "description": "Issue number to comment on"
+        },
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        }
+      },
+      "required": [
+        "owner",
+        "repo",
+        "issue_number",
+        "body"
+      ]
+    },
+    "annotations": {
+      "title": "Add comment to issue"
+    }
+  },
+  {
+    "name": "add_reply_to_pull_request_comment",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACwUlEQVRIie2Vz28UZRjHP993pi0QIC3YahNjirtmd3bS3Q1eUHvQEPUiEv8A4kXjwRJ78MCFBLjBBRKCHowHE38cNCbGGx6IUoKiodtNpoNmTJp4oSJNQ3pw29l5POxus2wo3QTwxPc0887zfD7zvu9kXnjEUfdNrjj5vJOmMP4e9JrfR1G02tuQD8tvgpck0dxCPwK30ViqnJTcr4bOmfRlI/PrhUJ5313woDpDpu8ss7f6nYHrvDnGcYlPsoY/bKaXwHY3HWfvgmNnMX0zvMM7069A3c3pkEYWa7UVgFxQPSfs7SSeH3k2rEy5jMubMBoG1yQ+SBbm53of+gCybMkk/H8VAFdbZisZLAFsJ11oyL+BUURcwrjWAZixXeIwxs/5UuVAr0QAYRjubGR+HWy3mb6QCIBXQe8nce0jgIkwfMo3/xLG085x8I9ofkMyUa0O+w2rgS0mcf3lboEDiKJo1cvsIDDr4D1DhTb8407hYhTdTJW+AvrdMnuhG9Je1m9BBzbfjXbyQcXypeqJLQt7+0rVE/mgYr3j7l7FDzOPBY8FDx6vc1EolPeNjI5/Jpgw7Lm9o+Pry//c/K0PhnLFyrSMDxE79jwxvn9079gvt28vrUD7V1EoFHalbltd2C7DfS4sAF4DTSdx7cL96LliZVriPPADuL+geRh0Z8il5SiKVn2ATENvCCYw78U/b8xdBcgHlYuGHQXuK5A4ClxM4vnXW8Lqp5JdWWt6h4CvWnsgxgDSbRZ3Gg0tCJ7sY4nGwDZOt/WBZtzN9FswLgM2sGann5mcPDaw5pWEHQH7cUu86SdkR3LF6tfrA814MNVpwNrM1leUxPXrSKfMeHcwdctyNotY8c3NbMX3LJsB3ZHsymDqlkHvYHYyievXWxPpSj4o75eYIuPWZof+vRKG4c61pncIx6gZsx34/5L/ACy3ElqUYhuvAAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABn0lEQVRIie2Vvy5EURDGvyMUkhUU/pS2Q2clwvIKqL0Cm9ArrBcQShJPoLFR2YaIhIjQ7a7E39IiCgqVn8KsPY697E3oTHPumTPf990z986M9Mfm/A0wKGlMUlnSlnPuOQQAE5LOnXOFWErAIvBK1S6BZBAzZ2fzcckHjXwVaAXSwD2wWYN8A2iKK1ABt3m+ZeDRnseIthdgDxioxd1o662tfZIO7Lnf8xcklST1StqRdORxNEualHQIDDvnTmvdIGE5vwdWgLy93bQX0w0UgSdgKMC3AdfA7ndpSgKbduUbYBoI/7Ju4BiYrYFfAl4iBbxAgOyPgV9xWYDQ3xCXKK79C/wL/KJZoeW8QpsJCy0C54AMULaGmQu7sIAW4MpaxTKwbQU3U4dAxmLzwLpxXAIJP2jKgkY8Xx4o1SFwBmx7+7RxTUnVb9Bpa9HDFiR1/SRgWH+6FT3/h2qK6sBpB0aBB7yB880NcpaWtGHXjCsVBmb5PDIvgJ46BJKW84q9AguV87Adp/Q+9O8UMfQjRBKSxiV1SNp3zp3Ug/sVewPruexhKwhGXQAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Add a reply to an existing pull request comment. This creates a new comment that is linked as a reply to the specified comment.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "body": {
+          "type": "string",
+          "description": "The text of the reply"
+        },
+        "commentId": {
+          "type": "number",
+          "description": "The ID of the comment to reply to"
+        },
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "pullNumber": {
+          "type": "number",
+          "description": "Pull request number"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        }
+      },
+      "required": [
+        "owner",
+        "repo",
+        "pullNumber",
+        "commentId",
+        "body"
+      ]
+    },
+    "annotations": {
+      "title": "Add reply to pull request comment"
+    }
+  },
+  {
+    "name": "assign_copilot_to_issue",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAC20lEQVRIidWUS4wMURSGv3O7kWmPEMRrSMzcbl1dpqtmGuOxsCKECCKxEBusSJhIWEhsWLFAbC1sWFiISBARCyQ2kzSZGaMxHokgXvGIiMH0PRZjpJqqHpb+TeX+59z//H/q5sD/DqlX9H1/zFeX2qzIKoFWYDKgwBtUymL0UkNaT3V3d3/+5wG2EGxB9TDIxGFMvhVhb9/drpN/NaDJC7MGdwJk6TDCv0Gvq0lve9R762GUNdFDLleaZNBrICGq+4yhvf9TJtP/KZNB2PrLlbBliBfRhajuAwnFVa/n8/nkxFkv3GO9oJrzgwVxdesV71ov6I2r5fxggfWCatYL9yYmUJgLPH7Q29WZ4OED6Me4wuAdeQK6MMqna9t0GuibBHFAmgZ9JMG9BhkXZWoSCDSATIq7aguBD0wBplq/tZBgYDIwKnZAs99mFRYD9vd/YK0dpcqhobM6d9haWyOULRTbAauwuNlvsxHTYP3iBnVyXGAa8BIYC3oVeAKioCtAPEE7FCOgR0ErIJdBBZgNskzh40+NF6K6s+9e91lp9osrxMnFoTSmSmPVsF+E5cB0YEDgtoMjjypd5wCy+WC9GnajhEAa4bkqV9LOHKwa9/yneYeyUqwX3AdyQ5EeVrrqro/hYL0g+ggemKh4HGbPmVu0+fB8U76lpR6XgJwZpoGUpNYiusZg1tXjkmCAav0OMTXfJC4eVYPqwbot6l4BCPqyLhd7lwMAWC/cYb3gi/UCzRaKOxsbFzVEM1iv2Ebt5v2Dm14qZbJecZf1Ah3UCrcTbbB+awHnjgHLgHeinHYqZ8aPSXWWy+XvcQZLpdKI9/0D7UbZiLIJmABckVSqo+/OrUrNgF+D8q1LEdcBrAJGAJ8ROlGeicorABWdAswE5gOjge8CF8Ad66v03IjqJb75WS0tE0YOmNWqLBGReaAzgIkMLrt3oM9UpSzCzW9pd+FpT8/7JK3/Gz8Ao5X6wtwP7N4AAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACCElEQVRIid2UPWsUYRSFn3dxWWJUkESiBgslFokfhehGiGClBBQx4h9IGlEh2ijYxh+gxEL/hIWwhYpF8KNZsFRJYdJEiUbjCkqisj4W+y6Mk5nd1U4PDMOce+45L3fmDvzXUDeo59WK+kb9rn5TF9R76jm1+2/NJ9QPtseSOv4nxrvVmQ6M05hRB9qZ98ZR1NRralntitdEwmw8wQ9HbS329rQKuKLW1XJO/aX6IqdWjr1Xk/y6lG4vMBdCqOacoZZ3uBBCVZ0HDrcK2AYs5ZkAuwBb1N8Dm5JEISXoAnqzOtU9QB+wVR3KCdgClDIr6kCc4c/0O1BLNnahiYpaSmmGY62e/JpCLJ4FpmmMaBHYCDwC5mmMZBQYBC7HnhvAK+B+fN4JHAM+R4+3wGQI4S7qaExtol+9o86pq+oX9Yk6ljjtGfVprK2qr9Xb6vaET109jjqb3Jac2XaM1PLNpok1Aep+G/+dfa24nADTX1EWTgOngLE2XCYKQL0DTfKex2WhXgCutxG9i/fFNlwWpgBQL6orcWyTaldToRbUA2pow61XL0WPFfXCb1HqkPowCj6q0+qIWsw7nlpUj6i31OXY+0AdbGpCRtNRGgt1AigCX4EqsJAYTR+wAzgEdAM/gApwM4TwOOm3JiARtBk4CYwAB4F+oIfGZi/HwOfAM6ASQviU5/Vv4xcBzmW2eT1nrQAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Assign Copilot to a specific issue in a GitHub repository.\n\nThis tool can help with the following outcomes:\n- a Pull Request created with source code changes to resolve the issue\n\n\nMore information can be found at:\n- https://docs.github.com/en/copilot/using-github-copilot/using-copilot-coding-agent-to-work-on-tasks/about-assigning-tasks-to-copilot\n",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "base_ref": {
+          "type": "string",
+          "description": "Git reference (e.g., branch) that the agent will start its work from. If not specified, defaults to the repository's default branch"
+        },
+        "custom_instructions": {
+          "type": "string",
+          "description": "Optional custom instructions to guide the agent beyond the issue body. Use this to provide additional context, constraints, or guidance that is not captured in the issue description"
+        },
+        "issue_number": {
+          "type": "number",
+          "description": "Issue number"
+        },
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        }
+      },
+      "required": [
+        "owner",
+        "repo",
+        "issue_number"
+      ]
+    },
+    "annotations": {
+      "title": "Assign Copilot to issue",
+      "idempotentHint": true
+    }
+  },
+  {
+    "name": "create_branch",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Create a new branch in a GitHub repository",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "branch": {
+          "type": "string",
+          "description": "Name for new branch"
+        },
+        "from_branch": {
+          "type": "string",
+          "description": "Source branch (defaults to repo default)"
+        },
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        }
+      },
+      "required": [
+        "owner",
+        "repo",
+        "branch"
+      ]
+    },
+    "annotations": {
+      "title": "Create branch"
+    }
+  },
+  {
+    "name": "create_or_update_file",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Create or update a single file in a GitHub repository. \nIf updating, you should provide the SHA of the file you want to update. Use this tool to create or update a file in a GitHub repository remotely; do not use it for local file operations.\n\nIn order to obtain the SHA of original file version before updating, use the following git command:\ngit rev-parse <branch>:<path to file>\n\nSHA MUST be provided for existing file updates.\n",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "branch": {
+          "type": "string",
+          "description": "Branch to create/update the file in"
+        },
+        "content": {
+          "type": "string",
+          "description": "Content of the file"
+        },
+        "message": {
+          "type": "string",
+          "description": "Commit message"
+        },
+        "owner": {
+          "type": "string",
+          "description": "Repository owner (username or organization)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path where to create/update the file"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        },
+        "sha": {
+          "type": "string",
+          "description": "The blob SHA of the file being replaced. Required if the file already exists."
+        }
+      },
+      "required": [
+        "owner",
+        "repo",
+        "path",
+        "content",
+        "message",
+        "branch"
+      ]
+    },
+    "annotations": {
+      "title": "Create or update file"
+    }
+  },
+  {
+    "name": "create_pull_request",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACwUlEQVRIie2Vz28UZRjHP993pi0QIC3YahNjirtmd3bS3Q1eUHvQEPUiEv8A4kXjwRJ78MCFBLjBBRKCHowHE38cNCbGGx6IUoKiodtNpoNmTJp4oSJNQ3pw29l5POxus2wo3QTwxPc0887zfD7zvu9kXnjEUfdNrjj5vJOmMP4e9JrfR1G02tuQD8tvgpck0dxCPwK30ViqnJTcr4bOmfRlI/PrhUJ5313woDpDpu8ss7f6nYHrvDnGcYlPsoY/bKaXwHY3HWfvgmNnMX0zvMM7069A3c3pkEYWa7UVgFxQPSfs7SSeH3k2rEy5jMubMBoG1yQ+SBbm53of+gCybMkk/H8VAFdbZisZLAFsJ11oyL+BUURcwrjWAZixXeIwxs/5UuVAr0QAYRjubGR+HWy3mb6QCIBXQe8nce0jgIkwfMo3/xLG085x8I9ofkMyUa0O+w2rgS0mcf3lboEDiKJo1cvsIDDr4D1DhTb8407hYhTdTJW+AvrdMnuhG9Je1m9BBzbfjXbyQcXypeqJLQt7+0rVE/mgYr3j7l7FDzOPBY8FDx6vc1EolPeNjI5/Jpgw7Lm9o+Pry//c/K0PhnLFyrSMDxE79jwxvn9079gvt28vrUD7V1EoFHalbltd2C7DfS4sAF4DTSdx7cL96LliZVriPPADuL+geRh0Z8il5SiKVn2ATENvCCYw78U/b8xdBcgHlYuGHQXuK5A4ClxM4vnXW8Lqp5JdWWt6h4CvWnsgxgDSbRZ3Gg0tCJ7sY4nGwDZOt/WBZtzN9FswLgM2sGann5mcPDaw5pWEHQH7cUu86SdkR3LF6tfrA814MNVpwNrM1leUxPXrSKfMeHcwdctyNotY8c3NbMX3LJsB3ZHsymDqlkHvYHYyievXWxPpSj4o75eYIuPWZof+vRKG4c61pncIx6gZsx34/5L/ACy3ElqUYhuvAAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABn0lEQVRIie2Vvy5EURDGvyMUkhUU/pS2Q2clwvIKqL0Cm9ArrBcQShJPoLFR2YaIhIjQ7a7E39IiCgqVn8KsPY697E3oTHPumTPf990z986M9Mfm/A0wKGlMUlnSlnPuOQQAE5LOnXOFWErAIvBK1S6BZBAzZ2fzcckHjXwVaAXSwD2wWYN8A2iKK1ABt3m+ZeDRnseIthdgDxioxd1o662tfZIO7Lnf8xcklST1StqRdORxNEualHQIDDvnTmvdIGE5vwdWgLy93bQX0w0UgSdgKMC3AdfA7ndpSgKbduUbYBoI/7Ju4BiYrYFfAl4iBbxAgOyPgV9xWYDQ3xCXKK79C/wL/KJZoeW8QpsJCy0C54AMULaGmQu7sIAW4MpaxTKwbQU3U4dAxmLzwLpxXAIJP2jKgkY8Xx4o1SFwBmx7+7RxTUnVb9Bpa9HDFiR1/SRgWH+6FT3/h2qK6sBpB0aBB7yB880NcpaWtGHXjCsVBmb5PDIvgJ46BJKW84q9AguV87Adp/Q+9O8UMfQjRBKSxiV1SNp3zp3Ug/sVewPruexhKwhGXQAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Create a new pull request in a GitHub repository.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "base": {
+          "type": "string",
+          "description": "Branch to merge into"
+        },
+        "body": {
+          "type": "string",
+          "description": "PR description"
+        },
+        "draft": {
+          "type": "boolean",
+          "description": "Create as draft PR"
+        },
+        "head": {
+          "type": "string",
+          "description": "Branch containing changes"
+        },
+        "maintainer_can_modify": {
+          "type": "boolean",
+          "description": "Allow maintainer edits"
+        },
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        },
+        "title": {
+          "type": "string",
+          "description": "PR title"
+        }
+      },
+      "required": [
+        "owner",
+        "repo",
+        "title",
+        "head",
+        "base"
+      ]
+    },
+    "annotations": {
+      "title": "Open new pull request"
+    }
+  },
+  {
+    "name": "create_pull_request_with_copilot",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAC20lEQVRIidWUS4wMURSGv3O7kWmPEMRrSMzcbl1dpqtmGuOxsCKECCKxEBusSJhIWEhsWLFAbC1sWFiISBARCyQ2kzSZGaMxHokgXvGIiMH0PRZjpJqqHpb+TeX+59z//H/q5sD/DqlX9H1/zFeX2qzIKoFWYDKgwBtUymL0UkNaT3V3d3/+5wG2EGxB9TDIxGFMvhVhb9/drpN/NaDJC7MGdwJk6TDCv0Gvq0lve9R762GUNdFDLleaZNBrICGq+4yhvf9TJtP/KZNB2PrLlbBliBfRhajuAwnFVa/n8/nkxFkv3GO9oJrzgwVxdesV71ov6I2r5fxggfWCatYL9yYmUJgLPH7Q29WZ4OED6Me4wuAdeQK6MMqna9t0GuibBHFAmgZ9JMG9BhkXZWoSCDSATIq7aguBD0wBplq/tZBgYDIwKnZAs99mFRYD9vd/YK0dpcqhobM6d9haWyOULRTbAauwuNlvsxHTYP3iBnVyXGAa8BIYC3oVeAKioCtAPEE7FCOgR0ErIJdBBZgNskzh40+NF6K6s+9e91lp9osrxMnFoTSmSmPVsF+E5cB0YEDgtoMjjypd5wCy+WC9GnajhEAa4bkqV9LOHKwa9/yneYeyUqwX3AdyQ5EeVrrqro/hYL0g+ggemKh4HGbPmVu0+fB8U76lpR6XgJwZpoGUpNYiusZg1tXjkmCAav0OMTXfJC4eVYPqwbot6l4BCPqyLhd7lwMAWC/cYb3gi/UCzRaKOxsbFzVEM1iv2Ebt5v2Dm14qZbJecZf1Ah3UCrcTbbB+awHnjgHLgHeinHYqZ8aPSXWWy+XvcQZLpdKI9/0D7UbZiLIJmABckVSqo+/OrUrNgF+D8q1LEdcBrAJGAJ8ROlGeicorABWdAswE5gOjge8CF8Ad66v03IjqJb75WS0tE0YOmNWqLBGReaAzgIkMLrt3oM9UpSzCzW9pd+FpT8/7JK3/Gz8Ao5X6wtwP7N4AAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACCElEQVRIid2UPWsUYRSFn3dxWWJUkESiBgslFokfhehGiGClBBQx4h9IGlEh2ijYxh+gxEL/hIWwhYpF8KNZsFRJYdJEiUbjCkqisj4W+y6Mk5nd1U4PDMOce+45L3fmDvzXUDeo59WK+kb9rn5TF9R76jm1+2/NJ9QPtseSOv4nxrvVmQ6M05hRB9qZ98ZR1NRralntitdEwmw8wQ9HbS329rQKuKLW1XJO/aX6IqdWjr1Xk/y6lG4vMBdCqOacoZZ3uBBCVZ0HDrcK2AYs5ZkAuwBb1N8Dm5JEISXoAnqzOtU9QB+wVR3KCdgClDIr6kCc4c/0O1BLNnahiYpaSmmGY62e/JpCLJ4FpmmMaBHYCDwC5mmMZBQYBC7HnhvAK+B+fN4JHAM+R4+3wGQI4S7qaExtol+9o86pq+oX9Yk6ljjtGfVprK2qr9Xb6vaET109jjqb3Jac2XaM1PLNpok1Aep+G/+dfa24nADTX1EWTgOngLE2XCYKQL0DTfKex2WhXgCutxG9i/fFNlwWpgBQL6orcWyTaldToRbUA2pow61XL0WPFfXCb1HqkPowCj6q0+qIWsw7nlpUj6i31OXY+0AdbGpCRtNRGgt1AigCX4EqsJAYTR+wAzgEdAM/gApwM4TwOOm3JiARtBk4CYwAB4F+oIfGZi/HwOfAM6ASQviU5/Vv4xcBzmW2eT1nrQAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Delegate a task to GitHub Copilot coding agent to perform in the background. The agent will create a pull request with the implementation. You should use this tool if the user asks to create a pull request to perform a specific task, or if the user asks Copilot to do something.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "base_ref": {
+          "type": "string",
+          "description": "Git reference (e.g., branch) that the agent will start its work from. If not specified, defaults to the repository's default branch"
+        },
+        "owner": {
+          "type": "string",
+          "description": "Repository owner. You can guess the owner, but confirm it with the user before proceeding."
+        },
+        "problem_statement": {
+          "type": "string",
+          "description": "Detailed description of the task to be performed (e.g., 'Implement a feature that does X', 'Fix bug Y', etc.)"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name. You can guess the repository name, but confirm it with the user before proceeding."
+        },
+        "title": {
+          "type": "string",
+          "description": "Title for the pull request that will be created"
+        }
+      },
+      "required": [
+        "owner",
+        "repo",
+        "problem_statement",
+        "title"
+      ]
+    },
+    "annotations": {
+      "title": "Perform task with GitHub Copilot coding agent",
+      "openWorldHint": false
+    }
+  },
+  {
+    "name": "create_repository",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Create a new GitHub repository in your account or specified organization",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "autoInit": {
+          "type": "boolean",
+          "description": "Initialize with README"
+        },
+        "description": {
+          "type": "string",
+          "description": "Repository description"
+        },
+        "name": {
+          "type": "string",
+          "description": "Repository name"
+        },
+        "organization": {
+          "type": "string",
+          "description": "Organization to create the repository in (omit to create in your personal account)"
+        },
+        "private": {
+          "type": "boolean",
+          "description": "Whether repo should be private"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "annotations": {
+      "title": "Create repository"
+    }
+  },
+  {
+    "name": "delete_file",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Delete a file from a GitHub repository",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "branch": {
+          "type": "string",
+          "description": "Branch to delete the file from"
+        },
+        "message": {
+          "type": "string",
+          "description": "Commit message"
+        },
+        "owner": {
+          "type": "string",
+          "description": "Repository owner (username or organization)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to the file to delete"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        }
+      },
+      "required": [
+        "owner",
+        "repo",
+        "path",
+        "message",
+        "branch"
+      ]
+    },
+    "annotations": {
+      "title": "Delete file",
+      "destructiveHint": true
+    }
+  },
+  {
+    "name": "fork_repository",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACuElEQVRIibWTTUhUYRiFn/fOdYyoydQxk4LEGzN3RudaLYL+qRaBQYsIItoHCW37ISNbRwUFLWoRZBEt+4EIooKoTdZQ6TWaNIgouzJkuGhG731b6JTojDNBntX3ne+c97zfH8wzZCbREm9bZ4hsQvkeDvl3+/r6xuYqEIvFFgdSvRuDqCrPMu6bVyUDrITTjdI1jR8KBbrj/fs3Q8WLp5p9Qx4BzVOUInIm058+XdAY0ztH6RLhSpAza1RlI2jENzhfqntfjAugEdTYMFEtS0GvonrKslNrZwWIhDYDMh6Wo4ODvaMfB9LPFaMHZGvJ8xHdAlzPDLx+8Smd/pE39SggAptnB2gwDBD6ReJvhSCpMFyq/uSa/NFX5UMJgGCaxywMwiH/bi4wh0SCOy1x5waiCUF2gnSW3AByEfSSZTsPVXFF9CDC4ALx7xU0ocLA87x8tG7ZHRUShsheVMKInMy46culArIj317WRpd7KB2GsAl4bKoccN2330t5ALBsJ7ASTvecoun6hNNt2U5QbM0oRip8E6Wt0gCUFPC12FKoGFnX0BgBDtVGG3/W1qzqz2a/5IrpLGt9pLahvhPhCKrnsiPDT2dqZv1kgGQyGc4FZg+wr8I93F6y0DzY29s7XlHAnw7j7dswgg2oRCYZPTBluzk51VEwXmQG0k8qbGRuWHbqiWWn/qlY0Uv+n5j3gKKvaCaSyeSimrqms4hsB4kurW9c0bSs/pnneflyXrOcACCn5jWEPSr0AAgczvlVTVT+ykojFlvTZNmOWvHU8QJnJVInLNtR2163vJy/7B0EpjYAqBhugVMVF8A3goZy/rJHFGa8P4fpCXosHm9PqwbiwzHAqyLvlvPP+dEKWG23dyh6C1g0RY0Jsv+Dm77/XwIAWlpbVzJh7gLAnHjw8d27z5V65xW/AVGM6Ekx9nZCAAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABoUlEQVRIibWUPS+EQRSFz0hsxaIgIZHYllDYiiiUEn6Bn0Dho6Nhf4GPjkYn8ZEgGqFRSNBoVTQKdhEROsk+mrt2svvu7Gutk7yZzJlz77nzztyR/hmulADSkkYk5SQdO+c+QwmAZkkTktolXTjnbkLiDJCniHsgFdCnTFNAHliuJE6bYANoAYaBF+AwYHBkmiGgFdi0HINR4lmrotXjVoG3gMEbsOLN2yzHTIFr8PRZG3s9rs/jo5At0fd6fFk1TfY/X4A14MyqmQrsYNo0pxbzCtwBTZUCUsAh8GHCKaDspnl6ZyZ3FnMA9AR2/BOYBzJVhUV9BshHrTVEkZKeJPXHNZA0IOkxttrrhzkgGdAlgXnTLv3GIAHsEh87QGNUrooHaEajkoYlFXYxaeO2je+SLp1z57Grr2J4DvwqWaVDrhv+3SAWrMvXgWcgZ10b3a01GuwDX8CWfV/AXr2Sd9lVXPC4ReM6q8XHOYMOG2897rZkrXZY0+WAK6DHHsRr4xJ/NjCTcXstC/gAxuPEBju5xKRb0phNT5xzD7UUW3d8A4p92DZKdSwEAAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Fork a GitHub repository to your account or specified organization",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "organization": {
+          "type": "string",
+          "description": "Organization to fork to"
+        },
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        }
+      },
+      "required": [
+        "owner",
+        "repo"
+      ]
+    },
+    "annotations": {
+      "title": "Fork repository"
+    }
+  },
+  {
+    "name": "get_commit",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Get details for a commit from a GitHub repository",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "include_diff": {
+          "type": "boolean",
+          "description": "Whether to include file diffs and stats in the response. Default is true.",
+          "default": true
+        },
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (min 1)",
+          "minimum": 1
+        },
+        "perPage": {
+          "type": "number",
+          "description": "Results per page for pagination (min 1, max 100)",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        },
+        "sha": {
+          "type": "string",
+          "description": "Commit SHA, branch name, or tag name"
+        }
+      },
+      "required": [
+        "owner",
+        "repo",
+        "sha"
+      ]
+    },
+    "annotations": {
+      "title": "Get commit details",
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "get_copilot_job_status",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAC20lEQVRIidWUS4wMURSGv3O7kWmPEMRrSMzcbl1dpqtmGuOxsCKECCKxEBusSJhIWEhsWLFAbC1sWFiISBARCyQ2kzSZGaMxHokgXvGIiMH0PRZjpJqqHpb+TeX+59z//H/q5sD/DqlX9H1/zFeX2qzIKoFWYDKgwBtUymL0UkNaT3V3d3/+5wG2EGxB9TDIxGFMvhVhb9/drpN/NaDJC7MGdwJk6TDCv0Gvq0lve9R762GUNdFDLleaZNBrICGq+4yhvf9TJtP/KZNB2PrLlbBliBfRhajuAwnFVa/n8/nkxFkv3GO9oJrzgwVxdesV71ov6I2r5fxggfWCatYL9yYmUJgLPH7Q29WZ4OED6Me4wuAdeQK6MMqna9t0GuibBHFAmgZ9JMG9BhkXZWoSCDSATIq7aguBD0wBplq/tZBgYDIwKnZAs99mFRYD9vd/YK0dpcqhobM6d9haWyOULRTbAauwuNlvsxHTYP3iBnVyXGAa8BIYC3oVeAKioCtAPEE7FCOgR0ErIJdBBZgNskzh40+NF6K6s+9e91lp9osrxMnFoTSmSmPVsF+E5cB0YEDgtoMjjypd5wCy+WC9GnajhEAa4bkqV9LOHKwa9/yneYeyUqwX3AdyQ5EeVrrqro/hYL0g+ggemKh4HGbPmVu0+fB8U76lpR6XgJwZpoGUpNYiusZg1tXjkmCAav0OMTXfJC4eVYPqwbot6l4BCPqyLhd7lwMAWC/cYb3gi/UCzRaKOxsbFzVEM1iv2Ebt5v2Dm14qZbJecZf1Ah3UCrcTbbB+awHnjgHLgHeinHYqZ8aPSXWWy+XvcQZLpdKI9/0D7UbZiLIJmABckVSqo+/OrUrNgF+D8q1LEdcBrAJGAJ8ROlGeicorABWdAswE5gOjge8CF8Ad66v03IjqJb75WS0tE0YOmNWqLBGReaAzgIkMLrt3oM9UpSzCzW9pd+FpT8/7JK3/Gz8Ao5X6wtwP7N4AAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACCElEQVRIid2UPWsUYRSFn3dxWWJUkESiBgslFokfhehGiGClBBQx4h9IGlEh2ijYxh+gxEL/hIWwhYpF8KNZsFRJYdJEiUbjCkqisj4W+y6Mk5nd1U4PDMOce+45L3fmDvzXUDeo59WK+kb9rn5TF9R76jm1+2/NJ9QPtseSOv4nxrvVmQ6M05hRB9qZ98ZR1NRralntitdEwmw8wQ9HbS329rQKuKLW1XJO/aX6IqdWjr1Xk/y6lG4vMBdCqOacoZZ3uBBCVZ0HDrcK2AYs5ZkAuwBb1N8Dm5JEISXoAnqzOtU9QB+wVR3KCdgClDIr6kCc4c/0O1BLNnahiYpaSmmGY62e/JpCLJ4FpmmMaBHYCDwC5mmMZBQYBC7HnhvAK+B+fN4JHAM+R4+3wGQI4S7qaExtol+9o86pq+oX9Yk6ljjtGfVprK2qr9Xb6vaET109jjqb3Jac2XaM1PLNpok1Aep+G/+dfa24nADTX1EWTgOngLE2XCYKQL0DTfKex2WhXgCutxG9i/fFNlwWpgBQL6orcWyTaldToRbUA2pow61XL0WPFfXCb1HqkPowCj6q0+qIWsw7nlpUj6i31OXY+0AdbGpCRtNRGgt1AigCX4EqsJAYTR+wAzgEdAM/gApwM4TwOOm3JiARtBk4CYwAB4F+oIfGZi/HwOfAM6ASQviU5/Vv4xcBzmW2eT1nrQAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Get the status of a GitHub Copilot coding agent job. Use this to check if a previously submitted task has completed and to get the pull request URL once it's created. Provide the job ID (from create_pull_request_with_copilot) or pull request number (from assign_copilot_to_issue), or any pull request you want agent sessions for.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Job ID or pull request number"
+        },
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        }
+      },
+      "required": [
+        "owner",
+        "repo",
+        "id"
+      ]
+    },
+    "annotations": {
+      "title": "Get Copilot coding agent job status",
+      "readOnlyHint": true,
+      "openWorldHint": false
+    }
+  },
+  {
+    "name": "get_file_contents",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Get the contents of a file or directory from a GitHub repository",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "owner": {
+          "type": "string",
+          "description": "Repository owner (username or organization)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to file/directory",
+          "default": "/"
+        },
+        "ref": {
+          "type": "string",
+          "description": "Accepts optional git refs such as `refs/tags/{tag}`, `refs/heads/{branch}` or `refs/pull/{pr_number}/head`"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        },
+        "sha": {
+          "type": "string",
+          "description": "Accepts optional commit SHA. If specified, it will be used instead of ref"
+        }
+      },
+      "required": [
+        "owner",
+        "repo"
+      ]
+    },
+    "annotations": {
+      "title": "Get file or directory contents",
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "get_label",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAC2UlEQVRIicWVMUyTaRjHf/+vVUpOJOdilOYoUvVreq2CDmLOwdlAS5xMbrrhBifjYG7QjYuJw108nZx1huLgYlw0QshxChUK2koxHHcuCmgsFfieG0or3kGPSoz/8X3f5/97nvfN8z7wmaVqm9FodFfR/EnMugy5giCAwYwgI9Ff9Hl9L9Lp1zUBgsGO+rqGwnlhF4CdwBSyAUwvS1G220zHBSFgHtmVxYWvfp2ZGSj8LyAcjgfZphTQZtAr7OdsZvSP9RIJR+LtQhcNusF+d1aUfPp05M8NAavmg8AOk3cmN56+s1Hpa7U/cviUYbcw3jgex9ZCKoBgsKM+0PDuAdBq2He5zOiTzZiXtc+NxRw598GeLRcWTuTz+UUAp3ygrqFwHmgzeWdqNQd4PpFOy/gedNQfaDz3UQXRaHRX0fNPGdzNZUZO12q+VuHIoV7g5Hu/1/IinX7tABTNnwR2SvRsxRzAzOsBGuuWfAkoX5FZFzCVHR95tFVAbiI9DEwj6wLwl5YVMTRYLTDsxjuRrgGYYz/kxkbvbXRWMOBB24cKYI9ks1X8hXQDaAaa5XG9WjImZgV71wI+m8qAv8y0t1pSmP0ITANTmHO2qqvRZDALlTdgHKyjWkx2YvQ2cHtTacMxYBhWK5DoF4TCkXj7Jg02VKsbOwI0Y+qvALZrOQXMC13cKkDSJWBuJUCqAhgbG3uF7IpBcn/k8KlPNQ+78U5QQuhy/vHjuQoAYPndwi9gw4bd2ufGYrWatxz8No50ExhaKsz9Vl6vAPL5/KKzoiTGG0fOg1oqCbvxTp/juw/M+zynu/yTwjoD58CBQ02ez/pAR4E+M69ntf3/o1Y3dqR050oAQz7P6Z6cfPRRw647MkOhUMAfaDyH+AloBKYNPRT292rQHoMOSp09J3TZlt5ezWazxX97VR3638RiX9ct+RImSyBcrDT0ETMyMp4ptRIgVX7QL6J/ALSUEwJ5rdg2AAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABxElEQVRIibWVvW4TURCFv0vlNEDcIHAkKAERJOIKSjoUArwBPwUFFaKIIngAJARCPIgdh4cgRBYt6ZIAEYEqdhpEw0fhCbkKa68dxyNtsfNzzpnZu3NhwpYGBdUqcA+4A1wEZiK0DawD74FWSml3JAJ1CngGLAIngU1gFfgZKWeAG8AFoAu8At6mlH6VtqTOqJ/UP2pDnRuQO6c27VlbrQ0Dvq121Fulag7q5qPmW18SdSqUd9Qrw4Jn9bNR21YrRQkvYixDKy/AuB3jWjocqKpdtXFU8AxrOTqZzp2PgvnaMRDUA+tB7mypG+OCZ3hbahPgRPguAR9LihaicEu9WcKxClzOi/fU1wPAk7rjgX0uEfNG3cs7mJjtE+wA5/olpZQEHgNf6K2NJyW4NeD7v7c4WptjSc0svlMjdzyM2fbdOyOA7x/T+7mzGj9H8xgIWuquevpw4HmsivkxwBdC/WJRsBKLqqPOHgH8aqybtcJlF0m1WLndUToJ5V31q9r3NOYk7Wh1Wa0PyK3HzA3l/4H3uzIrwFNgCThF7/x/AH5EylngOnAe6AAvgXcppd9DEWRE08DdeIou/RVgJaXUGYQzUfsL+zmwV7BtIq0AAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Get a specific label from a repository.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Label name."
+        },
+        "owner": {
+          "type": "string",
+          "description": "Repository owner (username or organization name)"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        }
+      },
+      "required": [
+        "owner",
+        "repo",
+        "name"
+      ]
+    },
+    "annotations": {
+      "title": "Get a specific label from a repository.",
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "get_latest_release",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Get the latest release in a GitHub repository",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        }
+      },
+      "required": [
+        "owner",
+        "repo"
+      ]
+    },
+    "annotations": {
+      "title": "Get latest release",
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "get_me",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACSUlEQVRIidWVv09TURTHP+e+2mJMEOLiQBig4GtN4WEHRQxGMfHHYkx0YpJJR+OmjMTNP0CjRv4DJyNETXTQODRQSkmJTweYBUw0KeX1HoeCKY3v0eKi3/Gdc74/zrs3F/53SJN9Jul6owhpAJQlvzT/HrB/LZB0h4YR+wjI7B6UBVW55ZfmPkY6a4J8FugQ1euOLbc7ttyuyDWLJhA7k0wNnNpvAulLefOKdiZM4BWLxbX6Yncm0xkPTB5lzS/lhwBtKUHS9c4qOiCqdxrJAVYKhXVE7iIMJt2h0TCe8BVt/1Cjm7OhPZXETK23mm5ZQMTGQom3YW0gACoS2hsqoNbJAwTm4FjocFtwEcCozYcajTBo+lLenEUTWzE7vFIorNcXXdc9EpCYB775pfwJQu5E1BqsVW6L8CoemHwy7d39vfN4+VJgeYhwGPRGGPleCQCkN+XdE3Tqz1W97y8tPIgkCCv092dc68gzkGFgHXiNsFrLJt2IjgGdwAfH6sTy8sJy0wK9xwbPieEFSlmRyY5DzvNcLrdV35PNZg9s/KzeFNEpII6aq35p7t2eAjXn5hOwqk718pfFxdXQ/EDP8Wy3scFLoMuxerIxSeMxFeuYpyjlZsgBvhZzK9bErgAVa+RJo+ldAn0p7wJwWpHJZsjrRVRlUuFMT3rgfEQCOw5stDlb082S70CCH9PAd2NlPFRAkRGEN8VisdKqgO/7mwJvEUZCBYCjwOdWyXdga7Nd9d9232SRCSo28oWKgjjVxxrElvY7/2/iF/Bu47CZ2fOnAAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABaElEQVRIidWUvUrDcBTFz79YnRSii4N2cVB8AuvgByKuQqmrILQPoe9SfABxV5wUna2IVLq1k11adffn4A3UNPknjQ56IARyzz3ncj8i/Xe4LCSgIGlD0qp9epJ07Zz7+HEFQBl4YBRNoPwb4u9AB6gA0/bsAy3gDVjLK+6syg4wGxMPLHYPZGp1VGDLWlHxcKrG2UziFDwe4UAvPZyLCHcsgwlPLETYmkSuz6Bp7x0PZy/CzQ6gYENuAUFMfA7o2pB9hXpN1m0VOzbQGXsOTDz/mpqBA05ijizEcZpG4v4CK5IaksqS+pKuJHUtXNLXbAJJd5KOnHPP41S+DbwCL0ANKMZwikAd6AED3y2MVG7ij8BiBn7JuANgOY3sgFurPFU8YtIDbry/DWDXhlfLKj6UW7fc5LsBToE+MJnDYMra1PCR2sDZuOJD+efAt22KXuC8pHZeA8td8FVQBZIJKQCWgMO8+X8Tn12zhtgfmPjeAAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Get details of the authenticated GitHub user. Use this when a request is about the user's own profile for GitHub. Or when information is missing to build other tool calls.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "annotations": {
+      "title": "Get my user profile",
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "get_release_by_tag",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Get a specific release by its tag name in a GitHub repository",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        },
+        "tag": {
+          "type": "string",
+          "description": "Tag name (e.g., 'v1.0.0')"
+        }
+      },
+      "required": [
+        "owner",
+        "repo",
+        "tag"
+      ]
+    },
+    "annotations": {
+      "title": "Get a release by tag name",
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "get_tag",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Get details about a specific git tag in a GitHub repository",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        },
+        "tag": {
+          "type": "string",
+          "description": "Tag name"
+        }
+      },
+      "required": [
+        "owner",
+        "repo",
+        "tag"
+      ]
+    },
+    "annotations": {
+      "title": "Get tag details",
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "get_team_members",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACSUlEQVRIidWVv09TURTHP+e+2mJMEOLiQBig4GtN4WEHRQxGMfHHYkx0YpJJR+OmjMTNP0CjRv4DJyNETXTQODRQSkmJTweYBUw0KeX1HoeCKY3v0eKi3/Gdc74/zrs3F/53SJN9Jul6owhpAJQlvzT/HrB/LZB0h4YR+wjI7B6UBVW55ZfmPkY6a4J8FugQ1euOLbc7ttyuyDWLJhA7k0wNnNpvAulLefOKdiZM4BWLxbX6Yncm0xkPTB5lzS/lhwBtKUHS9c4qOiCqdxrJAVYKhXVE7iIMJt2h0TCe8BVt/1Cjm7OhPZXETK23mm5ZQMTGQom3YW0gACoS2hsqoNbJAwTm4FjocFtwEcCozYcajTBo+lLenEUTWzE7vFIorNcXXdc9EpCYB775pfwJQu5E1BqsVW6L8CoemHwy7d39vfN4+VJgeYhwGPRGGPleCQCkN+XdE3Tqz1W97y8tPIgkCCv092dc68gzkGFgHXiNsFrLJt2IjgGdwAfH6sTy8sJy0wK9xwbPieEFSlmRyY5DzvNcLrdV35PNZg9s/KzeFNEpII6aq35p7t2eAjXn5hOwqk718pfFxdXQ/EDP8Wy3scFLoMuxerIxSeMxFeuYpyjlZsgBvhZzK9bErgAVa+RJo+ldAn0p7wJwWpHJZsjrRVRlUuFMT3rgfEQCOw5stDlb082S70CCH9PAd2NlPFRAkRGEN8VisdKqgO/7mwJvEUZCBYCjwOdWyXdga7Nd9d9232SRCSo28oWKgjjVxxrElvY7/2/iF/Bu47CZ2fOnAAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABaElEQVRIidWUvUrDcBTFz79YnRSii4N2cVB8AuvgByKuQqmrILQPoe9SfABxV5wUna2IVLq1k11adffn4A3UNPknjQ56IARyzz3ncj8i/Xe4LCSgIGlD0qp9epJ07Zz7+HEFQBl4YBRNoPwb4u9AB6gA0/bsAy3gDVjLK+6syg4wGxMPLHYPZGp1VGDLWlHxcKrG2UziFDwe4UAvPZyLCHcsgwlPLETYmkSuz6Bp7x0PZy/CzQ6gYENuAUFMfA7o2pB9hXpN1m0VOzbQGXsOTDz/mpqBA05ijizEcZpG4v4CK5IaksqS+pKuJHUtXNLXbAJJd5KOnHPP41S+DbwCL0ANKMZwikAd6AED3y2MVG7ij8BiBn7JuANgOY3sgFurPFU8YtIDbry/DWDXhlfLKj6UW7fc5LsBToE+MJnDYMra1PCR2sDZuOJD+efAt22KXuC8pHZeA8td8FVQBZIJKQCWgMO8+X8Tn12zhtgfmPjeAAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Get member usernames of a specific team in an organization. Limited to organizations accessible with current credentials",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "org": {
+          "type": "string",
+          "description": "Organization login (owner) that contains the team."
+        },
+        "team_slug": {
+          "type": "string",
+          "description": "Team slug"
+        }
+      },
+      "required": [
+        "org",
+        "team_slug"
+      ]
+    },
+    "annotations": {
+      "title": "Get team members",
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "get_teams",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACSUlEQVRIidWVv09TURTHP+e+2mJMEOLiQBig4GtN4WEHRQxGMfHHYkx0YpJJR+OmjMTNP0CjRv4DJyNETXTQODRQSkmJTweYBUw0KeX1HoeCKY3v0eKi3/Gdc74/zrs3F/53SJN9Jul6owhpAJQlvzT/HrB/LZB0h4YR+wjI7B6UBVW55ZfmPkY6a4J8FugQ1euOLbc7ttyuyDWLJhA7k0wNnNpvAulLefOKdiZM4BWLxbX6Yncm0xkPTB5lzS/lhwBtKUHS9c4qOiCqdxrJAVYKhXVE7iIMJt2h0TCe8BVt/1Cjm7OhPZXETK23mm5ZQMTGQom3YW0gACoS2hsqoNbJAwTm4FjocFtwEcCozYcajTBo+lLenEUTWzE7vFIorNcXXdc9EpCYB775pfwJQu5E1BqsVW6L8CoemHwy7d39vfN4+VJgeYhwGPRGGPleCQCkN+XdE3Tqz1W97y8tPIgkCCv092dc68gzkGFgHXiNsFrLJt2IjgGdwAfH6sTy8sJy0wK9xwbPieEFSlmRyY5DzvNcLrdV35PNZg9s/KzeFNEpII6aq35p7t2eAjXn5hOwqk718pfFxdXQ/EDP8Wy3scFLoMuxerIxSeMxFeuYpyjlZsgBvhZzK9bErgAVa+RJo+ldAn0p7wJwWpHJZsjrRVRlUuFMT3rgfEQCOw5stDlb082S70CCH9PAd2NlPFRAkRGEN8VisdKqgO/7mwJvEUZCBYCjwOdWyXdga7Nd9d9232SRCSo28oWKgjjVxxrElvY7/2/iF/Bu47CZ2fOnAAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABaElEQVRIidWUvUrDcBTFz79YnRSii4N2cVB8AuvgByKuQqmrILQPoe9SfABxV5wUna2IVLq1k11adffn4A3UNPknjQ56IARyzz3ncj8i/Xe4LCSgIGlD0qp9epJ07Zz7+HEFQBl4YBRNoPwb4u9AB6gA0/bsAy3gDVjLK+6syg4wGxMPLHYPZGp1VGDLWlHxcKrG2UziFDwe4UAvPZyLCHcsgwlPLETYmkSuz6Bp7x0PZy/CzQ6gYENuAUFMfA7o2pB9hXpN1m0VOzbQGXsOTDz/mpqBA05ijizEcZpG4v4CK5IaksqS+pKuJHUtXNLXbAJJd5KOnHPP41S+DbwCL0ANKMZwikAd6AED3y2MVG7ij8BiBn7JuANgOY3sgFurPFU8YtIDbry/DWDXhlfLKj6UW7fc5LsBToE+MJnDYMra1PCR2sDZuOJD+efAt22KXuC8pHZeA8td8FVQBZIJKQCWgMO8+X8Tn12zhtgfmPjeAAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Get details of the teams the user is a member of. Limited to organizations accessible with current credentials",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "user": {
+          "type": "string",
+          "description": "Username to get teams for. If not provided, uses the authenticated user."
+        }
+      }
+    },
+    "annotations": {
+      "title": "Get teams",
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "issue_read",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAC2UlEQVRIicWVMUyTaRjHf/+vVUpOJOdilOYoUvVreq2CDmLOwdlAS5xMbrrhBifjYG7QjYuJw108nZx1huLgYlw0QshxChUK2koxHHcuCmgsFfieG0or3kGPSoz/8X3f5/97nvfN8z7wmaVqm9FodFfR/EnMugy5giCAwYwgI9Ff9Hl9L9Lp1zUBgsGO+rqGwnlhF4CdwBSyAUwvS1G220zHBSFgHtmVxYWvfp2ZGSj8LyAcjgfZphTQZtAr7OdsZvSP9RIJR+LtQhcNusF+d1aUfPp05M8NAavmg8AOk3cmN56+s1Hpa7U/cviUYbcw3jgex9ZCKoBgsKM+0PDuAdBq2He5zOiTzZiXtc+NxRw598GeLRcWTuTz+UUAp3ygrqFwHmgzeWdqNQd4PpFOy/gedNQfaDz3UQXRaHRX0fNPGdzNZUZO12q+VuHIoV7g5Hu/1/IinX7tABTNnwR2SvRsxRzAzOsBGuuWfAkoX5FZFzCVHR95tFVAbiI9DEwj6wLwl5YVMTRYLTDsxjuRrgGYYz/kxkbvbXRWMOBB24cKYI9ks1X8hXQDaAaa5XG9WjImZgV71wI+m8qAv8y0t1pSmP0ITANTmHO2qqvRZDALlTdgHKyjWkx2YvQ2cHtTacMxYBhWK5DoF4TCkXj7Jg02VKsbOwI0Y+qvALZrOQXMC13cKkDSJWBuJUCqAhgbG3uF7IpBcn/k8KlPNQ+78U5QQuhy/vHjuQoAYPndwi9gw4bd2ufGYrWatxz8No50ExhaKsz9Vl6vAPL5/KKzoiTGG0fOg1oqCbvxTp/juw/M+zynu/yTwjoD58CBQ02ez/pAR4E+M69ntf3/o1Y3dqR050oAQz7P6Z6cfPRRw647MkOhUMAfaDyH+AloBKYNPRT292rQHoMOSp09J3TZlt5ezWazxX97VR3638RiX9ct+RImSyBcrDT0ETMyMp4ptRIgVX7QL6J/ALSUEwJ5rdg2AAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABxElEQVRIibWVvW4TURCFv0vlNEDcIHAkKAERJOIKSjoUArwBPwUFFaKIIngAJARCPIgdh4cgRBYt6ZIAEYEqdhpEw0fhCbkKa68dxyNtsfNzzpnZu3NhwpYGBdUqcA+4A1wEZiK0DawD74FWSml3JAJ1CngGLAIngU1gFfgZKWeAG8AFoAu8At6mlH6VtqTOqJ/UP2pDnRuQO6c27VlbrQ0Dvq121Fulag7q5qPmW18SdSqUd9Qrw4Jn9bNR21YrRQkvYixDKy/AuB3jWjocqKpdtXFU8AxrOTqZzp2PgvnaMRDUA+tB7mypG+OCZ3hbahPgRPguAR9LihaicEu9WcKxClzOi/fU1wPAk7rjgX0uEfNG3cs7mJjtE+wA5/olpZQEHgNf6K2NJyW4NeD7v7c4WptjSc0svlMjdzyM2fbdOyOA7x/T+7mzGj9H8xgIWuquevpw4HmsivkxwBdC/WJRsBKLqqPOHgH8aqybtcJlF0m1WLndUToJ5V31q9r3NOYk7Wh1Wa0PyK3HzA3l/4H3uzIrwFNgCThF7/x/AH5EylngOnAe6AAvgXcppd9DEWRE08DdeIou/RVgJaXUGYQzUfsL+zmwV7BtIq0AAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Get information about a specific issue in a GitHub repository.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "issue_number": {
+          "type": "number",
+          "description": "The number of the issue"
+        },
+        "method": {
+          "type": "string",
+          "description": "The read operation to perform on a single issue.\nOptions are:\n1. get - Get details of a specific issue.\n2. get_comments - Get issue comments.\n3. get_sub_issues - Get sub-issues of the issue.\n4. get_labels - Get labels assigned to the issue.\n",
+          "enum": [
+            "get",
+            "get_comments",
+            "get_sub_issues",
+            "get_labels"
+          ]
+        },
+        "owner": {
+          "type": "string",
+          "description": "The owner of the repository"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (min 1)",
+          "minimum": 1
+        },
+        "perPage": {
+          "type": "number",
+          "description": "Results per page for pagination (min 1, max 100)",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "repo": {
+          "type": "string",
+          "description": "The name of the repository"
+        }
+      },
+      "required": [
+        "method",
+        "owner",
+        "repo",
+        "issue_number"
+      ]
+    },
+    "annotations": {
+      "title": "Get issue details",
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "issue_write",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAC2UlEQVRIicWVMUyTaRjHf/+vVUpOJOdilOYoUvVreq2CDmLOwdlAS5xMbrrhBifjYG7QjYuJw108nZx1huLgYlw0QshxChUK2koxHHcuCmgsFfieG0or3kGPSoz/8X3f5/97nvfN8z7wmaVqm9FodFfR/EnMugy5giCAwYwgI9Ff9Hl9L9Lp1zUBgsGO+rqGwnlhF4CdwBSyAUwvS1G220zHBSFgHtmVxYWvfp2ZGSj8LyAcjgfZphTQZtAr7OdsZvSP9RIJR+LtQhcNusF+d1aUfPp05M8NAavmg8AOk3cmN56+s1Hpa7U/cviUYbcw3jgex9ZCKoBgsKM+0PDuAdBq2He5zOiTzZiXtc+NxRw598GeLRcWTuTz+UUAp3ygrqFwHmgzeWdqNQd4PpFOy/gedNQfaDz3UQXRaHRX0fNPGdzNZUZO12q+VuHIoV7g5Hu/1/IinX7tABTNnwR2SvRsxRzAzOsBGuuWfAkoX5FZFzCVHR95tFVAbiI9DEwj6wLwl5YVMTRYLTDsxjuRrgGYYz/kxkbvbXRWMOBB24cKYI9ks1X8hXQDaAaa5XG9WjImZgV71wI+m8qAv8y0t1pSmP0ITANTmHO2qqvRZDALlTdgHKyjWkx2YvQ2cHtTacMxYBhWK5DoF4TCkXj7Jg02VKsbOwI0Y+qvALZrOQXMC13cKkDSJWBuJUCqAhgbG3uF7IpBcn/k8KlPNQ+78U5QQuhy/vHjuQoAYPndwi9gw4bd2ufGYrWatxz8No50ExhaKsz9Vl6vAPL5/KKzoiTGG0fOg1oqCbvxTp/juw/M+zynu/yTwjoD58CBQ02ez/pAR4E+M69ntf3/o1Y3dqR050oAQz7P6Z6cfPRRw647MkOhUMAfaDyH+AloBKYNPRT292rQHoMOSp09J3TZlt5ezWazxX97VR3638RiX9ct+RImSyBcrDT0ETMyMp4ptRIgVX7QL6J/ALSUEwJ5rdg2AAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABxElEQVRIibWVvW4TURCFv0vlNEDcIHAkKAERJOIKSjoUArwBPwUFFaKIIngAJARCPIgdh4cgRBYt6ZIAEYEqdhpEw0fhCbkKa68dxyNtsfNzzpnZu3NhwpYGBdUqcA+4A1wEZiK0DawD74FWSml3JAJ1CngGLAIngU1gFfgZKWeAG8AFoAu8At6mlH6VtqTOqJ/UP2pDnRuQO6c27VlbrQ0Dvq121Fulag7q5qPmW18SdSqUd9Qrw4Jn9bNR21YrRQkvYixDKy/AuB3jWjocqKpdtXFU8AxrOTqZzp2PgvnaMRDUA+tB7mypG+OCZ3hbahPgRPguAR9LihaicEu9WcKxClzOi/fU1wPAk7rjgX0uEfNG3cs7mJjtE+wA5/olpZQEHgNf6K2NJyW4NeD7v7c4WptjSc0svlMjdzyM2fbdOyOA7x/T+7mzGj9H8xgIWuquevpw4HmsivkxwBdC/WJRsBKLqqPOHgH8aqybtcJlF0m1WLndUToJ5V31q9r3NOYk7Wh1Wa0PyK3HzA3l/4H3uzIrwFNgCThF7/x/AH5EylngOnAe6AAvgXcppd9DEWRE08DdeIou/RVgJaXUGYQzUfsL+zmwV7BtIq0AAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Create a new or update an existing issue in a GitHub repository.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "assignees": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Usernames to assign to this issue"
+        },
+        "body": {
+          "type": "string",
+          "description": "Issue body content"
+        },
+        "duplicate_of": {
+          "type": "number",
+          "description": "Issue number that this issue is a duplicate of. Only used when state_reason is 'duplicate'."
+        },
+        "issue_number": {
+          "type": "number",
+          "description": "Issue number to update"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Labels to apply to this issue"
+        },
+        "method": {
+          "type": "string",
+          "description": "Write operation to perform on a single issue.\nOptions are:\n- 'create' - creates a new issue.\n- 'update' - updates an existing issue.\n",
+          "enum": [
+            "create",
+            "update"
+          ]
+        },
+        "milestone": {
+          "type": "number",
+          "description": "Milestone number"
+        },
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        },
+        "state": {
+          "type": "string",
+          "description": "New state",
+          "enum": [
+            "open",
+            "closed"
+          ]
+        },
+        "state_reason": {
+          "type": "string",
+          "description": "Reason for the state change. Ignored unless state is changed.",
+          "enum": [
+            "completed",
+            "not_planned",
+            "duplicate"
+          ]
+        },
+        "title": {
+          "type": "string",
+          "description": "Issue title"
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of this issue. Only use if the repository has issue types configured. Use list_issue_types tool to get valid type values for the organization. If the repository doesn't support issue types, omit this parameter."
+        }
+      },
+      "required": [
+        "method",
+        "owner",
+        "repo"
+      ]
+    },
+    "annotations": {
+      "title": "Create or update issue."
+    }
+  },
+  {
+    "name": "list_branches",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "List branches in a GitHub repository",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (min 1)",
+          "minimum": 1
+        },
+        "perPage": {
+          "type": "number",
+          "description": "Results per page for pagination (min 1, max 100)",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        }
+      },
+      "required": [
+        "owner",
+        "repo"
+      ]
+    },
+    "annotations": {
+      "title": "List branches",
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "list_commits",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Get list of commits of a branch in a GitHub repository. Returns at least 30 results per page by default, but can return more if specified using the perPage parameter (up to 100).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "author": {
+          "type": "string",
+          "description": "Author username or email address to filter commits by"
+        },
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (min 1)",
+          "minimum": 1
+        },
+        "perPage": {
+          "type": "number",
+          "description": "Results per page for pagination (min 1, max 100)",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        },
+        "sha": {
+          "type": "string",
+          "description": "Commit SHA, branch or tag name to list commits of. If not provided, uses the default branch of the repository. If a commit SHA is provided, will list commits up to that SHA."
+        }
+      },
+      "required": [
+        "owner",
+        "repo"
+      ]
+    },
+    "annotations": {
+      "title": "List commits",
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "list_issue_types",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAC2UlEQVRIicWVMUyTaRjHf/+vVUpOJOdilOYoUvVreq2CDmLOwdlAS5xMbrrhBifjYG7QjYuJw108nZx1huLgYlw0QshxChUK2koxHHcuCmgsFfieG0or3kGPSoz/8X3f5/97nvfN8z7wmaVqm9FodFfR/EnMugy5giCAwYwgI9Ff9Hl9L9Lp1zUBgsGO+rqGwnlhF4CdwBSyAUwvS1G220zHBSFgHtmVxYWvfp2ZGSj8LyAcjgfZphTQZtAr7OdsZvSP9RIJR+LtQhcNusF+d1aUfPp05M8NAavmg8AOk3cmN56+s1Hpa7U/cviUYbcw3jgex9ZCKoBgsKM+0PDuAdBq2He5zOiTzZiXtc+NxRw598GeLRcWTuTz+UUAp3ygrqFwHmgzeWdqNQd4PpFOy/gedNQfaDz3UQXRaHRX0fNPGdzNZUZO12q+VuHIoV7g5Hu/1/IinX7tABTNnwR2SvRsxRzAzOsBGuuWfAkoX5FZFzCVHR95tFVAbiI9DEwj6wLwl5YVMTRYLTDsxjuRrgGYYz/kxkbvbXRWMOBB24cKYI9ks1X8hXQDaAaa5XG9WjImZgV71wI+m8qAv8y0t1pSmP0ITANTmHO2qqvRZDALlTdgHKyjWkx2YvQ2cHtTacMxYBhWK5DoF4TCkXj7Jg02VKsbOwI0Y+qvALZrOQXMC13cKkDSJWBuJUCqAhgbG3uF7IpBcn/k8KlPNQ+78U5QQuhy/vHjuQoAYPndwi9gw4bd2ufGYrWatxz8No50ExhaKsz9Vl6vAPL5/KKzoiTGG0fOg1oqCbvxTp/juw/M+zynu/yTwjoD58CBQ02ez/pAR4E+M69ntf3/o1Y3dqR050oAQz7P6Z6cfPRRw647MkOhUMAfaDyH+AloBKYNPRT292rQHoMOSp09J3TZlt5ezWazxX97VR3638RiX9ct+RImSyBcrDT0ETMyMp4ptRIgVX7QL6J/ALSUEwJ5rdg2AAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABxElEQVRIibWVvW4TURCFv0vlNEDcIHAkKAERJOIKSjoUArwBPwUFFaKIIngAJARCPIgdh4cgRBYt6ZIAEYEqdhpEw0fhCbkKa68dxyNtsfNzzpnZu3NhwpYGBdUqcA+4A1wEZiK0DawD74FWSml3JAJ1CngGLAIngU1gFfgZKWeAG8AFoAu8At6mlH6VtqTOqJ/UP2pDnRuQO6c27VlbrQ0Dvq121Fulag7q5qPmW18SdSqUd9Qrw4Jn9bNR21YrRQkvYixDKy/AuB3jWjocqKpdtXFU8AxrOTqZzp2PgvnaMRDUA+tB7mypG+OCZ3hbahPgRPguAR9LihaicEu9WcKxClzOi/fU1wPAk7rjgX0uEfNG3cs7mJjtE+wA5/olpZQEHgNf6K2NJyW4NeD7v7c4WptjSc0svlMjdzyM2fbdOyOA7x/T+7mzGj9H8xgIWuquevpw4HmsivkxwBdC/WJRsBKLqqPOHgH8aqybtcJlF0m1WLndUToJ5V31q9r3NOYk7Wh1Wa0PyK3HzA3l/4H3uzIrwFNgCThF7/x/AH5EylngOnAe6AAvgXcppd9DEWRE08DdeIou/RVgJaXUGYQzUfsL+zmwV7BtIq0AAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "List supported issue types for repository owner (organization).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "owner": {
+          "type": "string",
+          "description": "The organization owner of the repository"
+        }
+      },
+      "required": [
+        "owner"
+      ]
+    },
+    "annotations": {
+      "title": "List available issue types",
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "list_issues",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAC2UlEQVRIicWVMUyTaRjHf/+vVUpOJOdilOYoUvVreq2CDmLOwdlAS5xMbrrhBifjYG7QjYuJw108nZx1huLgYlw0QshxChUK2koxHHcuCmgsFfieG0or3kGPSoz/8X3f5/97nvfN8z7wmaVqm9FodFfR/EnMugy5giCAwYwgI9Ff9Hl9L9Lp1zUBgsGO+rqGwnlhF4CdwBSyAUwvS1G220zHBSFgHtmVxYWvfp2ZGSj8LyAcjgfZphTQZtAr7OdsZvSP9RIJR+LtQhcNusF+d1aUfPp05M8NAavmg8AOk3cmN56+s1Hpa7U/cviUYbcw3jgex9ZCKoBgsKM+0PDuAdBq2He5zOiTzZiXtc+NxRw598GeLRcWTuTz+UUAp3ygrqFwHmgzeWdqNQd4PpFOy/gedNQfaDz3UQXRaHRX0fNPGdzNZUZO12q+VuHIoV7g5Hu/1/IinX7tABTNnwR2SvRsxRzAzOsBGuuWfAkoX5FZFzCVHR95tFVAbiI9DEwj6wLwl5YVMTRYLTDsxjuRrgGYYz/kxkbvbXRWMOBB24cKYI9ks1X8hXQDaAaa5XG9WjImZgV71wI+m8qAv8y0t1pSmP0ITANTmHO2qqvRZDALlTdgHKyjWkx2YvQ2cHtTacMxYBhWK5DoF4TCkXj7Jg02VKsbOwI0Y+qvALZrOQXMC13cKkDSJWBuJUCqAhgbG3uF7IpBcn/k8KlPNQ+78U5QQuhy/vHjuQoAYPndwi9gw4bd2ufGYrWatxz8No50ExhaKsz9Vl6vAPL5/KKzoiTGG0fOg1oqCbvxTp/juw/M+zynu/yTwjoD58CBQ02ez/pAR4E+M69ntf3/o1Y3dqR050oAQz7P6Z6cfPRRw647MkOhUMAfaDyH+AloBKYNPRT292rQHoMOSp09J3TZlt5ezWazxX97VR3638RiX9ct+RImSyBcrDT0ETMyMp4ptRIgVX7QL6J/ALSUEwJ5rdg2AAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABxElEQVRIibWVvW4TURCFv0vlNEDcIHAkKAERJOIKSjoUArwBPwUFFaKIIngAJARCPIgdh4cgRBYt6ZIAEYEqdhpEw0fhCbkKa68dxyNtsfNzzpnZu3NhwpYGBdUqcA+4A1wEZiK0DawD74FWSml3JAJ1CngGLAIngU1gFfgZKWeAG8AFoAu8At6mlH6VtqTOqJ/UP2pDnRuQO6c27VlbrQ0Dvq121Fulag7q5qPmW18SdSqUd9Qrw4Jn9bNR21YrRQkvYixDKy/AuB3jWjocqKpdtXFU8AxrOTqZzp2PgvnaMRDUA+tB7mypG+OCZ3hbahPgRPguAR9LihaicEu9WcKxClzOi/fU1wPAk7rjgX0uEfNG3cs7mJjtE+wA5/olpZQEHgNf6K2NJyW4NeD7v7c4WptjSc0svlMjdzyM2fbdOyOA7x/T+7mzGj9H8xgIWuquevpw4HmsivkxwBdC/WJRsBKLqqPOHgH8aqybtcJlF0m1WLndUToJ5V31q9r3NOYk7Wh1Wa0PyK3HzA3l/4H3uzIrwFNgCThF7/x/AH5EylngOnAe6AAvgXcppd9DEWRE08DdeIou/RVgJaXUGYQzUfsL+zmwV7BtIq0AAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "List issues in a GitHub repository. For pagination, use the 'endCursor' from the previous response's 'pageInfo' in the 'after' parameter.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "after": {
+          "type": "string",
+          "description": "Cursor for pagination. Use the endCursor from the previous page's PageInfo for GraphQL APIs."
+        },
+        "direction": {
+          "type": "string",
+          "description": "Order direction. If provided, the 'orderBy' also needs to be provided.",
+          "enum": [
+            "ASC",
+            "DESC"
+          ]
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Filter by labels"
+        },
+        "orderBy": {
+          "type": "string",
+          "description": "Order issues by field. If provided, the 'direction' also needs to be provided.",
+          "enum": [
+            "CREATED_AT",
+            "UPDATED_AT",
+            "COMMENTS"
+          ]
+        },
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "perPage": {
+          "type": "number",
+          "description": "Results per page for pagination (min 1, max 100)",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        },
+        "since": {
+          "type": "string",
+          "description": "Filter by date (ISO 8601 timestamp)"
+        },
+        "state": {
+          "type": "string",
+          "description": "Filter by state, by default both open and closed issues are returned when not provided",
+          "enum": [
+            "OPEN",
+            "CLOSED"
+          ]
+        }
+      },
+      "required": [
+        "owner",
+        "repo"
+      ]
+    },
+    "annotations": {
+      "title": "List issues",
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "list_pull_requests",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACwUlEQVRIie2Vz28UZRjHP993pi0QIC3YahNjirtmd3bS3Q1eUHvQEPUiEv8A4kXjwRJ78MCFBLjBBRKCHowHE38cNCbGGx6IUoKiodtNpoNmTJp4oSJNQ3pw29l5POxus2wo3QTwxPc0887zfD7zvu9kXnjEUfdNrjj5vJOmMP4e9JrfR1G02tuQD8tvgpck0dxCPwK30ViqnJTcr4bOmfRlI/PrhUJ5313woDpDpu8ss7f6nYHrvDnGcYlPsoY/bKaXwHY3HWfvgmNnMX0zvMM7069A3c3pkEYWa7UVgFxQPSfs7SSeH3k2rEy5jMubMBoG1yQ+SBbm53of+gCybMkk/H8VAFdbZisZLAFsJ11oyL+BUURcwrjWAZixXeIwxs/5UuVAr0QAYRjubGR+HWy3mb6QCIBXQe8nce0jgIkwfMo3/xLG085x8I9ofkMyUa0O+w2rgS0mcf3lboEDiKJo1cvsIDDr4D1DhTb8407hYhTdTJW+AvrdMnuhG9Je1m9BBzbfjXbyQcXypeqJLQt7+0rVE/mgYr3j7l7FDzOPBY8FDx6vc1EolPeNjI5/Jpgw7Lm9o+Pry//c/K0PhnLFyrSMDxE79jwxvn9079gvt28vrUD7V1EoFHalbltd2C7DfS4sAF4DTSdx7cL96LliZVriPPADuL+geRh0Z8il5SiKVn2ATENvCCYw78U/b8xdBcgHlYuGHQXuK5A4ClxM4vnXW8Lqp5JdWWt6h4CvWnsgxgDSbRZ3Gg0tCJ7sY4nGwDZOt/WBZtzN9FswLgM2sGann5mcPDaw5pWEHQH7cUu86SdkR3LF6tfrA814MNVpwNrM1leUxPXrSKfMeHcwdctyNotY8c3NbMX3LJsB3ZHsymDqlkHvYHYyievXWxPpSj4o75eYIuPWZof+vRKG4c61pncIx6gZsx34/5L/ACy3ElqUYhuvAAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABn0lEQVRIie2Vvy5EURDGvyMUkhUU/pS2Q2clwvIKqL0Cm9ArrBcQShJPoLFR2YaIhIjQ7a7E39IiCgqVn8KsPY697E3oTHPumTPf990z986M9Mfm/A0wKGlMUlnSlnPuOQQAE5LOnXOFWErAIvBK1S6BZBAzZ2fzcckHjXwVaAXSwD2wWYN8A2iKK1ABt3m+ZeDRnseIthdgDxioxd1o662tfZIO7Lnf8xcklST1StqRdORxNEualHQIDDvnTmvdIGE5vwdWgLy93bQX0w0UgSdgKMC3AdfA7ndpSgKbduUbYBoI/7Ju4BiYrYFfAl4iBbxAgOyPgV9xWYDQ3xCXKK79C/wL/KJZoeW8QpsJCy0C54AMULaGmQu7sIAW4MpaxTKwbQU3U4dAxmLzwLpxXAIJP2jKgkY8Xx4o1SFwBmx7+7RxTUnVb9Bpa9HDFiR1/SRgWH+6FT3/h2qK6sBpB0aBB7yB880NcpaWtGHXjCsVBmb5PDIvgJ46BJKW84q9AguV87Adp/Q+9O8UMfQjRBKSxiV1SNp3zp3Ug/sVewPruexhKwhGXQAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "List pull requests in a GitHub repository. If the user specifies an author, then DO NOT use this tool and use the search_pull_requests tool instead.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "base": {
+          "type": "string",
+          "description": "Filter by base branch"
+        },
+        "direction": {
+          "type": "string",
+          "description": "Sort direction",
+          "enum": [
+            "asc",
+            "desc"
+          ]
+        },
+        "head": {
+          "type": "string",
+          "description": "Filter by head user/org and branch"
+        },
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (min 1)",
+          "minimum": 1
+        },
+        "perPage": {
+          "type": "number",
+          "description": "Results per page for pagination (min 1, max 100)",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        },
+        "sort": {
+          "type": "string",
+          "description": "Sort by",
+          "enum": [
+            "created",
+            "updated",
+            "popularity",
+            "long-running"
+          ]
+        },
+        "state": {
+          "type": "string",
+          "description": "Filter by state",
+          "enum": [
+            "open",
+            "closed",
+            "all"
+          ]
+        }
+      },
+      "required": [
+        "owner",
+        "repo"
+      ]
+    },
+    "annotations": {
+      "title": "List pull requests",
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "list_releases",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "List releases in a GitHub repository",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (min 1)",
+          "minimum": 1
+        },
+        "perPage": {
+          "type": "number",
+          "description": "Results per page for pagination (min 1, max 100)",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        }
+      },
+      "required": [
+        "owner",
+        "repo"
+      ]
+    },
+    "annotations": {
+      "title": "List releases",
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "list_tags",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "List git tags in a GitHub repository",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (min 1)",
+          "minimum": 1
+        },
+        "perPage": {
+          "type": "number",
+          "description": "Results per page for pagination (min 1, max 100)",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        }
+      },
+      "required": [
+        "owner",
+        "repo"
+      ]
+    },
+    "annotations": {
+      "title": "List tags",
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "merge_pull_request",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACeElEQVRIibWVTUhUYRSGn/e74+iiQih1F9Vcmj9sptylUVBYkO4jcNeuJBdFKxe1CYQokGrRKjCEdtmqwEVmtqomQWeiUdc2EBUtUufe0yLHn1KLGXtX5zvn4zz3vd8f/Gfp90Qs0drmpA6MT1EveDo1NfV92wB+KnMdo39Nfs4L7eSHD5Nz1QJcJYglWtsw+iUehAuRRjO1g+0KHLerbb4OIHnHAC1FdW129s3XmUJuwnBDoOPbA7BwHsD7QWq1HKYN5msBRCpB1AueLoSROSkciSUyj5ClhE6BLtYC8CpBqVRabNrdMmIiJdQjuUbQ1WI+d78WwIbykxnzU9np7ejlNq2YxQ4ebNtTKyCyWcEgYl55EDj/a7ihFEtkLkr0As2YxjwL+9aem00dCEYNzvnJzLDvH27aaM5y80HEnKGHKGwPnEbT6fSOvzpAmrDQnkncpC7siiUzz2QqIPu25iOuGBorTufO/AJmH0v2ajHwuoHhrQHATOH9rQPJ7IjDLgs6kZ0F6it1AzArVcZLdUE+WnYgmv/uYFmz+dxH4NJGNT+RfYLCE7F4tn0pGkxHy94AmBm8/GfAVvIs7AukUTkbj5YdYIbZ9WJh8m1lzrrbNB4/tD+QuyPsdCibF26gmM/dY/NdRDqd3rEYeN04mswYL+ZXm68DxOPxnWXXMClsp+GGhCWBTtClYj53t1qXK78oVH2XYB/mHZ0pvHsN4Cczzw3rBaoGrJ6D5ZUvN1i+kjI0LWiptjmscbC88hZZCAf2trZeq1v0UsJ6wF7UAlhxUMxPvkW6AboQLbvPcjaO+BIx11cL4I9H308eOiLRQUhpOx79/66fNKzrOCYNDm0AAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABjElEQVRIibWVPS/DURTGnysSC0HiZdWVrZ28JDaLT8BHaBsMdjqZJDXiAzC2LF5mX6GtATGiIsGARH+Gnj9X8a/kf3uWe3Py3Oc559xz75E6bK7VAWQkzUi6lXTonHsOpgYUgAZfdgmkQpFnjHwb6AemgDpQCiWwYlEPeL4i8JCEt8vb39g67vkmPH8yA3qt5nVgCzi1jLJBBEwkBZSAdxPKAj86LYQQQCU4cYvAKzDUSYF3YC+uRIAD8sA58ACU//VuTODE1n1g+A9c3jBH1tJ1a5TeCPNrdACSCpKeJG1IepN0LKkm6dGDrkqqOOdm7dyUpDNJi865PUnqjsvEObcJHEhaljQnaV5STwvszttXbR2J441KtB4LauLKVpZpYBDYte8mHUogZTWPrAGstTtQBl6AayDX7qHZD7AALMVGDvQBV5ZyETi2qHLtMvmXWRQAk57vBKgl4fV/0+jmq56vImk0icCnAWm7pB3riGngnlADx0TW+T4yL4CxJJy/Df20mkP/TqGHfifsA7INs3X5i3+yAAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Merge a pull request in a GitHub repository.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "commit_message": {
+          "type": "string",
+          "description": "Extra detail for merge commit"
+        },
+        "commit_title": {
+          "type": "string",
+          "description": "Title for merge commit"
+        },
+        "merge_method": {
+          "type": "string",
+          "description": "Merge method",
+          "enum": [
+            "merge",
+            "squash",
+            "rebase"
+          ]
+        },
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "pullNumber": {
+          "type": "number",
+          "description": "Pull request number"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        }
+      },
+      "required": [
+        "owner",
+        "repo",
+        "pullNumber"
+      ]
+    },
+    "annotations": {
+      "title": "Merge pull request"
+    }
+  },
+  {
+    "name": "pull_request_read",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACwUlEQVRIie2Vz28UZRjHP993pi0QIC3YahNjirtmd3bS3Q1eUHvQEPUiEv8A4kXjwRJ78MCFBLjBBRKCHowHE38cNCbGGx6IUoKiodtNpoNmTJp4oSJNQ3pw29l5POxus2wo3QTwxPc0887zfD7zvu9kXnjEUfdNrjj5vJOmMP4e9JrfR1G02tuQD8tvgpck0dxCPwK30ViqnJTcr4bOmfRlI/PrhUJ5313woDpDpu8ss7f6nYHrvDnGcYlPsoY/bKaXwHY3HWfvgmNnMX0zvMM7069A3c3pkEYWa7UVgFxQPSfs7SSeH3k2rEy5jMubMBoG1yQ+SBbm53of+gCybMkk/H8VAFdbZisZLAFsJ11oyL+BUURcwrjWAZixXeIwxs/5UuVAr0QAYRjubGR+HWy3mb6QCIBXQe8nce0jgIkwfMo3/xLG085x8I9ofkMyUa0O+w2rgS0mcf3lboEDiKJo1cvsIDDr4D1DhTb8407hYhTdTJW+AvrdMnuhG9Je1m9BBzbfjXbyQcXypeqJLQt7+0rVE/mgYr3j7l7FDzOPBY8FDx6vc1EolPeNjI5/Jpgw7Lm9o+Pry//c/K0PhnLFyrSMDxE79jwxvn9079gvt28vrUD7V1EoFHalbltd2C7DfS4sAF4DTSdx7cL96LliZVriPPADuL+geRh0Z8il5SiKVn2ATENvCCYw78U/b8xdBcgHlYuGHQXuK5A4ClxM4vnXW8Lqp5JdWWt6h4CvWnsgxgDSbRZ3Gg0tCJ7sY4nGwDZOt/WBZtzN9FswLgM2sGann5mcPDaw5pWEHQH7cUu86SdkR3LF6tfrA814MNVpwNrM1leUxPXrSKfMeHcwdctyNotY8c3NbMX3LJsB3ZHsymDqlkHvYHYyievXWxPpSj4o75eYIuPWZof+vRKG4c61pncIx6gZsx34/5L/ACy3ElqUYhuvAAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABn0lEQVRIie2Vvy5EURDGvyMUkhUU/pS2Q2clwvIKqL0Cm9ArrBcQShJPoLFR2YaIhIjQ7a7E39IiCgqVn8KsPY697E3oTHPumTPf990z986M9Mfm/A0wKGlMUlnSlnPuOQQAE5LOnXOFWErAIvBK1S6BZBAzZ2fzcckHjXwVaAXSwD2wWYN8A2iKK1ABt3m+ZeDRnseIthdgDxioxd1o662tfZIO7Lnf8xcklST1StqRdORxNEualHQIDDvnTmvdIGE5vwdWgLy93bQX0w0UgSdgKMC3AdfA7ndpSgKbduUbYBoI/7Ju4BiYrYFfAl4iBbxAgOyPgV9xWYDQ3xCXKK79C/wL/KJZoeW8QpsJCy0C54AMULaGmQu7sIAW4MpaxTKwbQU3U4dAxmLzwLpxXAIJP2jKgkY8Xx4o1SFwBmx7+7RxTUnVb9Bpa9HDFiR1/SRgWH+6FT3/h2qK6sBpB0aBB7yB880NcpaWtGHXjCsVBmb5PDIvgJ46BJKW84q9AguV87Adp/Q+9O8UMfQjRBKSxiV1SNp3zp3Ug/sVewPruexhKwhGXQAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Get information on a specific pull request in GitHub repository.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "method": {
+          "type": "string",
+          "description": "Action to specify what pull request data needs to be retrieved from GitHub. \nPossible options: \n 1. get - Get details of a specific pull request.\n 2. get_diff - Get the diff of a pull request.\n 3. get_status - Get combined commit status of a head commit in a pull request.\n 4. get_files - Get the list of files changed in a pull request. Use with pagination parameters to control the number of results returned.\n 5. get_review_comments - Get review threads on a pull request. Each thread contains logically grouped review comments made on the same code location during pull request reviews. Returns threads with metadata (isResolved, isOutdated, isCollapsed) and their associated comments. Use cursor-based pagination (perPage, after) to control results.\n 6. get_reviews - Get the reviews on a pull request. When asked for review comments, use get_review_comments method.\n 7. get_comments - Get comments on a pull request. Use this if user doesn't specifically want review comments. Use with pagination parameters to control the number of results returned.\n 8. get_check_runs - Get check runs for the head commit of a pull request. Check runs are the individual CI/CD jobs and checks that run on the PR.\n",
+          "enum": [
+            "get",
+            "get_diff",
+            "get_status",
+            "get_files",
+            "get_review_comments",
+            "get_reviews",
+            "get_comments",
+            "get_check_runs"
+          ]
+        },
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (min 1)",
+          "minimum": 1
+        },
+        "perPage": {
+          "type": "number",
+          "description": "Results per page for pagination (min 1, max 100)",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "pullNumber": {
+          "type": "number",
+          "description": "Pull request number"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        }
+      },
+      "required": [
+        "method",
+        "owner",
+        "repo",
+        "pullNumber"
+      ]
+    },
+    "annotations": {
+      "title": "Get details for a single pull request",
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "pull_request_review_write",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACwUlEQVRIie2Vz28UZRjHP993pi0QIC3YahNjirtmd3bS3Q1eUHvQEPUiEv8A4kXjwRJ78MCFBLjBBRKCHowHE38cNCbGGx6IUoKiodtNpoNmTJp4oSJNQ3pw29l5POxus2wo3QTwxPc0887zfD7zvu9kXnjEUfdNrjj5vJOmMP4e9JrfR1G02tuQD8tvgpck0dxCPwK30ViqnJTcr4bOmfRlI/PrhUJ5313woDpDpu8ss7f6nYHrvDnGcYlPsoY/bKaXwHY3HWfvgmNnMX0zvMM7069A3c3pkEYWa7UVgFxQPSfs7SSeH3k2rEy5jMubMBoG1yQ+SBbm53of+gCybMkk/H8VAFdbZisZLAFsJ11oyL+BUURcwrjWAZixXeIwxs/5UuVAr0QAYRjubGR+HWy3mb6QCIBXQe8nce0jgIkwfMo3/xLG085x8I9ofkMyUa0O+w2rgS0mcf3lboEDiKJo1cvsIDDr4D1DhTb8407hYhTdTJW+AvrdMnuhG9Je1m9BBzbfjXbyQcXypeqJLQt7+0rVE/mgYr3j7l7FDzOPBY8FDx6vc1EolPeNjI5/Jpgw7Lm9o+Pry//c/K0PhnLFyrSMDxE79jwxvn9079gvt28vrUD7V1EoFHalbltd2C7DfS4sAF4DTSdx7cL96LliZVriPPADuL+geRh0Z8il5SiKVn2ATENvCCYw78U/b8xdBcgHlYuGHQXuK5A4ClxM4vnXW8Lqp5JdWWt6h4CvWnsgxgDSbRZ3Gg0tCJ7sY4nGwDZOt/WBZtzN9FswLgM2sGann5mcPDaw5pWEHQH7cUu86SdkR3LF6tfrA814MNVpwNrM1leUxPXrSKfMeHcwdctyNotY8c3NbMX3LJsB3ZHsymDqlkHvYHYyievXWxPpSj4o75eYIuPWZof+vRKG4c61pncIx6gZsx34/5L/ACy3ElqUYhuvAAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABn0lEQVRIie2Vvy5EURDGvyMUkhUU/pS2Q2clwvIKqL0Cm9ArrBcQShJPoLFR2YaIhIjQ7a7E39IiCgqVn8KsPY697E3oTHPumTPf990z986M9Mfm/A0wKGlMUlnSlnPuOQQAE5LOnXOFWErAIvBK1S6BZBAzZ2fzcckHjXwVaAXSwD2wWYN8A2iKK1ABt3m+ZeDRnseIthdgDxioxd1o662tfZIO7Lnf8xcklST1StqRdORxNEualHQIDDvnTmvdIGE5vwdWgLy93bQX0w0UgSdgKMC3AdfA7ndpSgKbduUbYBoI/7Ju4BiYrYFfAl4iBbxAgOyPgV9xWYDQ3xCXKK79C/wL/KJZoeW8QpsJCy0C54AMULaGmQu7sIAW4MpaxTKwbQU3U4dAxmLzwLpxXAIJP2jKgkY8Xx4o1SFwBmx7+7RxTUnVb9Bpa9HDFiR1/SRgWH+6FT3/h2qK6sBpB0aBB7yB880NcpaWtGHXjCsVBmb5PDIvgJ46BJKW84q9AguV87Adp/Q+9O8UMfQjRBKSxiV1SNp3zp3Ug/sVewPruexhKwhGXQAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Create and/or submit, delete review of a pull request.\n\nAvailable methods:\n- create: Create a new review of a pull request. If \"event\" parameter is provided, the review is submitted. If \"event\" is omitted, a pending review is created.\n- submit_pending: Submit an existing pending review of a pull request. This requires that a pending review exists for the current user on the specified pull request. The \"body\" and \"event\" parameters are used when submitting the review.\n- delete_pending: Delete an existing pending review of a pull request. This requires that a pending review exists for the current user on the specified pull request.\n",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "body": {
+          "type": "string",
+          "description": "Review comment text"
+        },
+        "commitID": {
+          "type": "string",
+          "description": "SHA of commit to review"
+        },
+        "event": {
+          "type": "string",
+          "description": "Review action to perform.",
+          "enum": [
+            "APPROVE",
+            "REQUEST_CHANGES",
+            "COMMENT"
+          ]
+        },
+        "method": {
+          "type": "string",
+          "description": "The write operation to perform on pull request review.",
+          "enum": [
+            "create",
+            "submit_pending",
+            "delete_pending"
+          ]
+        },
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "pullNumber": {
+          "type": "number",
+          "description": "Pull request number"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        }
+      },
+      "required": [
+        "method",
+        "owner",
+        "repo",
+        "pullNumber"
+      ]
+    },
+    "annotations": {
+      "title": "Write operations (create, submit, delete) on pull request reviews."
+    }
+  },
+  {
+    "name": "push_files",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Push multiple files to a GitHub repository in a single commit",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "branch": {
+          "type": "string",
+          "description": "Branch to push to"
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "content": {
+                "type": "string",
+                "description": "file content"
+              },
+              "path": {
+                "type": "string",
+                "description": "path to the file"
+              }
+            },
+            "required": [
+              "path",
+              "content"
+            ]
+          },
+          "description": "Array of file objects to push, each object with path (string) and content (string)"
+        },
+        "message": {
+          "type": "string",
+          "description": "Commit message"
+        },
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        }
+      },
+      "required": [
+        "owner",
+        "repo",
+        "branch",
+        "files",
+        "message"
+      ]
+    },
+    "annotations": {
+      "title": "Push files to repository"
+    }
+  },
+  {
+    "name": "request_copilot_review",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAC20lEQVRIidWUS4wMURSGv3O7kWmPEMRrSMzcbl1dpqtmGuOxsCKECCKxEBusSJhIWEhsWLFAbC1sWFiISBARCyQ2kzSZGaMxHokgXvGIiMH0PRZjpJqqHpb+TeX+59z//H/q5sD/DqlX9H1/zFeX2qzIKoFWYDKgwBtUymL0UkNaT3V3d3/+5wG2EGxB9TDIxGFMvhVhb9/drpN/NaDJC7MGdwJk6TDCv0Gvq0lve9R762GUNdFDLleaZNBrICGq+4yhvf9TJtP/KZNB2PrLlbBliBfRhajuAwnFVa/n8/nkxFkv3GO9oJrzgwVxdesV71ov6I2r5fxggfWCatYL9yYmUJgLPH7Q29WZ4OED6Me4wuAdeQK6MMqna9t0GuibBHFAmgZ9JMG9BhkXZWoSCDSATIq7aguBD0wBplq/tZBgYDIwKnZAs99mFRYD9vd/YK0dpcqhobM6d9haWyOULRTbAauwuNlvsxHTYP3iBnVyXGAa8BIYC3oVeAKioCtAPEE7FCOgR0ErIJdBBZgNskzh40+NF6K6s+9e91lp9osrxMnFoTSmSmPVsF+E5cB0YEDgtoMjjypd5wCy+WC9GnajhEAa4bkqV9LOHKwa9/yneYeyUqwX3AdyQ5EeVrrqro/hYL0g+ggemKh4HGbPmVu0+fB8U76lpR6XgJwZpoGUpNYiusZg1tXjkmCAav0OMTXfJC4eVYPqwbot6l4BCPqyLhd7lwMAWC/cYb3gi/UCzRaKOxsbFzVEM1iv2Ebt5v2Dm14qZbJecZf1Ah3UCrcTbbB+awHnjgHLgHeinHYqZ8aPSXWWy+XvcQZLpdKI9/0D7UbZiLIJmABckVSqo+/OrUrNgF+D8q1LEdcBrAJGAJ8ROlGeicorABWdAswE5gOjge8CF8Ad66v03IjqJb75WS0tE0YOmNWqLBGReaAzgIkMLrt3oM9UpSzCzW9pd+FpT8/7JK3/Gz8Ao5X6wtwP7N4AAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACCElEQVRIid2UPWsUYRSFn3dxWWJUkESiBgslFokfhehGiGClBBQx4h9IGlEh2ijYxh+gxEL/hIWwhYpF8KNZsFRJYdJEiUbjCkqisj4W+y6Mk5nd1U4PDMOce+45L3fmDvzXUDeo59WK+kb9rn5TF9R76jm1+2/NJ9QPtseSOv4nxrvVmQ6M05hRB9qZ98ZR1NRralntitdEwmw8wQ9HbS329rQKuKLW1XJO/aX6IqdWjr1Xk/y6lG4vMBdCqOacoZZ3uBBCVZ0HDrcK2AYs5ZkAuwBb1N8Dm5JEISXoAnqzOtU9QB+wVR3KCdgClDIr6kCc4c/0O1BLNnahiYpaSmmGY62e/JpCLJ4FpmmMaBHYCDwC5mmMZBQYBC7HnhvAK+B+fN4JHAM+R4+3wGQI4S7qaExtol+9o86pq+oX9Yk6ljjtGfVprK2qr9Xb6vaET109jjqb3Jac2XaM1PLNpok1Aep+G/+dfa24nADTX1EWTgOngLE2XCYKQL0DTfKex2WhXgCutxG9i/fFNlwWpgBQL6orcWyTaldToRbUA2pow61XL0WPFfXCb1HqkPowCj6q0+qIWsw7nlpUj6i31OXY+0AdbGpCRtNRGgt1AigCX4EqsJAYTR+wAzgEdAM/gApwM4TwOOm3JiARtBk4CYwAB4F+oIfGZi/HwOfAM6ASQviU5/Vv4xcBzmW2eT1nrQAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Request a GitHub Copilot code review for a pull request. Use this for automated feedback on pull requests, usually before requesting a human reviewer.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "pullNumber": {
+          "type": "number",
+          "description": "Pull request number"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        }
+      },
+      "required": [
+        "owner",
+        "repo",
+        "pullNumber"
+      ]
+    },
+    "annotations": {
+      "title": "Request Copilot review"
+    }
+  },
+  {
+    "name": "search_code",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Fast and precise code search across ALL GitHub repositories using GitHub's native search engine. Best for finding exact symbols, functions, classes, or specific code patterns.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "order": {
+          "type": "string",
+          "description": "Sort order for results",
+          "enum": [
+            "asc",
+            "desc"
+          ]
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (min 1)",
+          "minimum": 1
+        },
+        "perPage": {
+          "type": "number",
+          "description": "Results per page for pagination (min 1, max 100)",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "query": {
+          "type": "string",
+          "description": "Search query using GitHub's powerful code search syntax. Examples: 'content:Skill language:Java org:github', 'NOT is:archived language:Python OR language:go', 'repo:github/github-mcp-server'. Supports exact matching, language filters, path filters, and more."
+        },
+        "sort": {
+          "type": "string",
+          "description": "Sort field ('indexed' only)"
+        }
+      },
+      "required": [
+        "query"
+      ]
+    },
+    "annotations": {
+      "title": "Search code",
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "search_issues",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAC2UlEQVRIicWVMUyTaRjHf/+vVUpOJOdilOYoUvVreq2CDmLOwdlAS5xMbrrhBifjYG7QjYuJw108nZx1huLgYlw0QshxChUK2koxHHcuCmgsFfieG0or3kGPSoz/8X3f5/97nvfN8z7wmaVqm9FodFfR/EnMugy5giCAwYwgI9Ff9Hl9L9Lp1zUBgsGO+rqGwnlhF4CdwBSyAUwvS1G220zHBSFgHtmVxYWvfp2ZGSj8LyAcjgfZphTQZtAr7OdsZvSP9RIJR+LtQhcNusF+d1aUfPp05M8NAavmg8AOk3cmN56+s1Hpa7U/cviUYbcw3jgex9ZCKoBgsKM+0PDuAdBq2He5zOiTzZiXtc+NxRw598GeLRcWTuTz+UUAp3ygrqFwHmgzeWdqNQd4PpFOy/gedNQfaDz3UQXRaHRX0fNPGdzNZUZO12q+VuHIoV7g5Hu/1/IinX7tABTNnwR2SvRsxRzAzOsBGuuWfAkoX5FZFzCVHR95tFVAbiI9DEwj6wLwl5YVMTRYLTDsxjuRrgGYYz/kxkbvbXRWMOBB24cKYI9ks1X8hXQDaAaa5XG9WjImZgV71wI+m8qAv8y0t1pSmP0ITANTmHO2qqvRZDALlTdgHKyjWkx2YvQ2cHtTacMxYBhWK5DoF4TCkXj7Jg02VKsbOwI0Y+qvALZrOQXMC13cKkDSJWBuJUCqAhgbG3uF7IpBcn/k8KlPNQ+78U5QQuhy/vHjuQoAYPndwi9gw4bd2ufGYrWatxz8No50ExhaKsz9Vl6vAPL5/KKzoiTGG0fOg1oqCbvxTp/juw/M+zynu/yTwjoD58CBQ02ez/pAR4E+M69ntf3/o1Y3dqR050oAQz7P6Z6cfPRRw647MkOhUMAfaDyH+AloBKYNPRT292rQHoMOSp09J3TZlt5ezWazxX97VR3638RiX9ct+RImSyBcrDT0ETMyMp4ptRIgVX7QL6J/ALSUEwJ5rdg2AAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABxElEQVRIibWVvW4TURCFv0vlNEDcIHAkKAERJOIKSjoUArwBPwUFFaKIIngAJARCPIgdh4cgRBYt6ZIAEYEqdhpEw0fhCbkKa68dxyNtsfNzzpnZu3NhwpYGBdUqcA+4A1wEZiK0DawD74FWSml3JAJ1CngGLAIngU1gFfgZKWeAG8AFoAu8At6mlH6VtqTOqJ/UP2pDnRuQO6c27VlbrQ0Dvq121Fulag7q5qPmW18SdSqUd9Qrw4Jn9bNR21YrRQkvYixDKy/AuB3jWjocqKpdtXFU8AxrOTqZzp2PgvnaMRDUA+tB7mypG+OCZ3hbahPgRPguAR9LihaicEu9WcKxClzOi/fU1wPAk7rjgX0uEfNG3cs7mJjtE+wA5/olpZQEHgNf6K2NJyW4NeD7v7c4WptjSc0svlMjdzyM2fbdOyOA7x/T+7mzGj9H8xgIWuquevpw4HmsivkxwBdC/WJRsBKLqqPOHgH8aqybtcJlF0m1WLndUToJ5V31q9r3NOYk7Wh1Wa0PyK3HzA3l/4H3uzIrwFNgCThF7/x/AH5EylngOnAe6AAvgXcppd9DEWRE08DdeIou/RVgJaXUGYQzUfsL+zmwV7BtIq0AAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Search for issues in GitHub repositories using issues search syntax already scoped to is:issue",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "order": {
+          "type": "string",
+          "description": "Sort order",
+          "enum": [
+            "asc",
+            "desc"
+          ]
+        },
+        "owner": {
+          "type": "string",
+          "description": "Optional repository owner. If provided with repo, only issues for this repository are listed."
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (min 1)",
+          "minimum": 1
+        },
+        "perPage": {
+          "type": "number",
+          "description": "Results per page for pagination (min 1, max 100)",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "query": {
+          "type": "string",
+          "description": "Search query using GitHub issues search syntax"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Optional repository name. If provided with owner, only issues for this repository are listed."
+        },
+        "sort": {
+          "type": "string",
+          "description": "Sort field by number of matches of categories, defaults to best match",
+          "enum": [
+            "comments",
+            "reactions",
+            "reactions-+1",
+            "reactions--1",
+            "reactions-smile",
+            "reactions-thinking_face",
+            "reactions-heart",
+            "reactions-tada",
+            "interactions",
+            "created",
+            "updated"
+          ]
+        }
+      },
+      "required": [
+        "query"
+      ]
+    },
+    "annotations": {
+      "title": "Search issues",
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "search_pull_requests",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACwUlEQVRIie2Vz28UZRjHP993pi0QIC3YahNjirtmd3bS3Q1eUHvQEPUiEv8A4kXjwRJ78MCFBLjBBRKCHowHE38cNCbGGx6IUoKiodtNpoNmTJp4oSJNQ3pw29l5POxus2wo3QTwxPc0887zfD7zvu9kXnjEUfdNrjj5vJOmMP4e9JrfR1G02tuQD8tvgpck0dxCPwK30ViqnJTcr4bOmfRlI/PrhUJ5313woDpDpu8ss7f6nYHrvDnGcYlPsoY/bKaXwHY3HWfvgmNnMX0zvMM7069A3c3pkEYWa7UVgFxQPSfs7SSeH3k2rEy5jMubMBoG1yQ+SBbm53of+gCybMkk/H8VAFdbZisZLAFsJ11oyL+BUURcwrjWAZixXeIwxs/5UuVAr0QAYRjubGR+HWy3mb6QCIBXQe8nce0jgIkwfMo3/xLG085x8I9ofkMyUa0O+w2rgS0mcf3lboEDiKJo1cvsIDDr4D1DhTb8407hYhTdTJW+AvrdMnuhG9Je1m9BBzbfjXbyQcXypeqJLQt7+0rVE/mgYr3j7l7FDzOPBY8FDx6vc1EolPeNjI5/Jpgw7Lm9o+Pry//c/K0PhnLFyrSMDxE79jwxvn9079gvt28vrUD7V1EoFHalbltd2C7DfS4sAF4DTSdx7cL96LliZVriPPADuL+geRh0Z8il5SiKVn2ATENvCCYw78U/b8xdBcgHlYuGHQXuK5A4ClxM4vnXW8Lqp5JdWWt6h4CvWnsgxgDSbRZ3Gg0tCJ7sY4nGwDZOt/WBZtzN9FswLgM2sGann5mcPDaw5pWEHQH7cUu86SdkR3LF6tfrA814MNVpwNrM1leUxPXrSKfMeHcwdctyNotY8c3NbMX3LJsB3ZHsymDqlkHvYHYyievXWxPpSj4o75eYIuPWZof+vRKG4c61pncIx6gZsx34/5L/ACy3ElqUYhuvAAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABn0lEQVRIie2Vvy5EURDGvyMUkhUU/pS2Q2clwvIKqL0Cm9ArrBcQShJPoLFR2YaIhIjQ7a7E39IiCgqVn8KsPY697E3oTHPumTPf990z986M9Mfm/A0wKGlMUlnSlnPuOQQAE5LOnXOFWErAIvBK1S6BZBAzZ2fzcckHjXwVaAXSwD2wWYN8A2iKK1ABt3m+ZeDRnseIthdgDxioxd1o662tfZIO7Lnf8xcklST1StqRdORxNEualHQIDDvnTmvdIGE5vwdWgLy93bQX0w0UgSdgKMC3AdfA7ndpSgKbduUbYBoI/7Ju4BiYrYFfAl4iBbxAgOyPgV9xWYDQ3xCXKK79C/wL/KJZoeW8QpsJCy0C54AMULaGmQu7sIAW4MpaxTKwbQU3U4dAxmLzwLpxXAIJP2jKgkY8Xx4o1SFwBmx7+7RxTUnVb9Bpa9HDFiR1/SRgWH+6FT3/h2qK6sBpB0aBB7yB880NcpaWtGHXjCsVBmb5PDIvgJ46BJKW84q9AguV87Adp/Q+9O8UMfQjRBKSxiV1SNp3zp3Ug/sVewPruexhKwhGXQAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Search for pull requests in GitHub repositories using issues search syntax already scoped to is:pr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "order": {
+          "type": "string",
+          "description": "Sort order",
+          "enum": [
+            "asc",
+            "desc"
+          ]
+        },
+        "owner": {
+          "type": "string",
+          "description": "Optional repository owner. If provided with repo, only pull requests for this repository are listed."
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (min 1)",
+          "minimum": 1
+        },
+        "perPage": {
+          "type": "number",
+          "description": "Results per page for pagination (min 1, max 100)",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "query": {
+          "type": "string",
+          "description": "Search query using GitHub pull request search syntax"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Optional repository name. If provided with owner, only pull requests for this repository are listed."
+        },
+        "sort": {
+          "type": "string",
+          "description": "Sort field by number of matches of categories, defaults to best match",
+          "enum": [
+            "comments",
+            "reactions",
+            "reactions-+1",
+            "reactions--1",
+            "reactions-smile",
+            "reactions-thinking_face",
+            "reactions-heart",
+            "reactions-tada",
+            "interactions",
+            "created",
+            "updated"
+          ]
+        }
+      },
+      "required": [
+        "query"
+      ]
+    },
+    "annotations": {
+      "title": "Search pull requests",
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "search_repositories",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABTklEQVRIie2UPUvDUBSGn5PW2qnYwUXExWhNpY2CUKT+BB10E3R0dnbrppuKLgouHbr5X5qlKRIFB+cuguBHj4O05KYfNsVJ+m7n3Hue54ZcrhDKQqGQTX1YVwg7QIbx0gh8b7VTJMMrqS+5RtgD7oDX2GhhC6UcbhkCVLZVuX1sesex4YCdX6uAGgIrsicjlrTGgQ9KVPDnmQgmgongPwgkXNiOq8ADMAtkx4UGvtflJvus20ANeIlN/vW5/kkt8L3D2HD6P9dRgSI8dQcc9w1IR3acBE3vbFSp8ZMVnoFSqJ/unZDe3pAYXyDIJarn9opbDZrewaAh2y7Oy5S1r6h5QG2Xxbw3piDw6xe244oKyxFmC5ihc+tS1qaqngKJyAEBGmZvSGzHVYT790T7aPozsaFoFZGboFGvDJsbOYuOuxuuc7n1uaV8sRSH8Q1DUVLnYLty3gAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAA+ElEQVRIie2WLU5DQRRGzwUEirQCQ9BsoSGtZQHgSFgIsg4JXQCGP8V2QCBIEATZkJDgOJi+MJnMo30TFHmfmzvzfeeKyZ2BROpQvVHfrddDmhkZ4BY4Ai6BD7prAowjIoq7i85nFcGNf6qa1tayM1vAvBZQUg74c/WAHtAD/gMgn6YCT8A2MKwOTaZpCfAF3AGvFdlLx7XqdUVw4186rgWeE8Nn4cU67QLNAS/ASG3qmwVPqdaqjWw9A86BK+CkzaTuAseFBse/AiLiQg1gLzs3Bwb8XIp94AxYL/Af2xordap6v/htHKhv6nTlgBUAh9l6Rx11yfgG8ne/zwh2OysAAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Find GitHub repositories by name, description, readme, topics, or other metadata. Perfect for discovering projects, finding examples, or locating specific repositories across GitHub.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "minimal_output": {
+          "type": "boolean",
+          "description": "Return minimal repository information (default: true). When false, returns full GitHub API repository objects.",
+          "default": true
+        },
+        "order": {
+          "type": "string",
+          "description": "Sort order",
+          "enum": [
+            "asc",
+            "desc"
+          ]
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (min 1)",
+          "minimum": 1
+        },
+        "perPage": {
+          "type": "number",
+          "description": "Results per page for pagination (min 1, max 100)",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "query": {
+          "type": "string",
+          "description": "Repository search query. Examples: 'machine learning in:name stars:>1000 language:python', 'topic:react', 'user:facebook'. Supports advanced search syntax for precise filtering."
+        },
+        "sort": {
+          "type": "string",
+          "description": "Sort repositories by field, defaults to best match",
+          "enum": [
+            "stars",
+            "forks",
+            "help-wanted-issues",
+            "updated"
+          ]
+        }
+      },
+      "required": [
+        "query"
+      ]
+    },
+    "annotations": {
+      "title": "Search repositories",
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "search_users",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAADWklEQVRIidWTT2hcVRTGf+e+mUn9Q3WMqbbWgJ1JnMw4meiAUkoxIRG1IKK4ELqoVkQXUsVuXbropoq4EWykuBDURV2I0r9GrC0VopnXTGaefYkhDahBOg4SnSTv3eMiTphMJ6Spq57dPd+933e/794DN3rJWkA+n49W54MB4AE1aoyawqVS1xn4PPzfAsnUg48iOgyaaIJ8I7r/5wn3u2sVMM2N7nTvbsQeB42J6nOOrW12bG2zIs8ohFblZHe6d/d1Oejv74/MzlU8lGibCfqKxeKVRrwzm43HAlMAatvviqdHRkaC9QScxkVk021DwAFRfalcGv+xeXN1bq52x5ats8Crf80vnL3yx29TiZ7e59s7tg7Ft3TEc5n09PT0tG08syoiEckBGF04seaVFtuOA1ixuf9OvQP6rqj5avb3SmlHKptdU0BhaT3L1gbLsVpRgMlSYdvNUb1VlKeAqBFzsjObjbcWMNYFCMxNg2sJmE3B4wCOmEK957ru/KVy4UtxnCeBO2OheaOONX9Tk+zJlRXsUsTunLl4sdIIplKp9oC2MYR//FJ3T6uZSKZzZ7Es+OXCIECkOQFVeUFET8UCU0im+w7WMydWeyKwHEboUCuDaw2cKGpFVx76qjmYLI+dRzkE3IvqZ0RrVaK1KsqnCNsROTTpjX3fijyReSip8LCo+aFlRN3d2ZR15COQnUAFOIVwedmbdCI6CMSBc47V/Z7neivkqWxexHwC2h4lmi2VRn9dJZC4Pzcghi9Qaoq8dfstztHR0dFVvyqfz0f/nA9fFNG3gRhqnvbLP30LkOzJfQP0Kzw7WSocW+Vg+ebmAjCjTrhncnz8cqsI6rUjk+80NvgauMex+ojnuV4ynTuMcgD4G/RNv+QO199ArGOGUWrXQg4wVRydCTF7gCVr5Agg/kThIE6YQjkH8mEi1bcPQLp6+h5T9AToy37JPbIeeWN1pXOvqPKBFR2amnBPA2QymdiidY4pMmhCEgbsXqDSZsKPN0IOoIvzR4GqsbK33isWi4vG8hogoaOvG0V2oXK6WCwublTA9/0FgTMIuxr7nuf+AowIDBjgboz6GyVfcSF4wLarAGEcuC8iyj4JuXC9Ak5o3g8j4fnmvpXIe44NWg7kjVX/Ap7dYx0LcmfJAAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAB20lEQVRIidXUvUuVcRQH8PPc1JYUrKWUDCmwoKa2QsTKoKEwxWhr6G1tqDVqaAn8F6I5oS0ipBp6WZqiAi1bEgIrIpcorD4NHvFye+7Vrkv94Dc853zP93venl/E/36Keg60RsRgROyOiEpEPI+IB0VR/FyzKgYw48/zBv1rJe/HN7zDKNrzDmMqfc2JoAVvk3xjib8zfa/R0ozA4WzFaAPMWGKG8vskLuDIiqK4lMHtDTAdibmY3+9rZrSnGl+piV9YqcpY3jwREUVRdEXEhog4GhGtETGJznrZHchMhhtUcCIxh0p8u/ADV+sFV3KAU2VZYBNmE7OuDsdj3K+XYGAfvua2jGXPOzLz2VzT/Q3iH2GykUCByyU/2dK50iB2B77jWj3ATjxNos+4hfG8E2mDJ+irid2LaXzCljLyQcxjDmctvkW1mFacwwd8wUCV72GKH6+X+TxeYGvd/i3je/AqRfrSNo6F5DldDS6y5LnVkFfFbcPHHGqRtu24i184tQQcytLOrJa8SuR8xh6ssrXhTm5bd+BmDq+tCYH12aYbNfbe3KbrYfH9mPhb8iqy25gusd/Ds0pEbI6ImWYFImI6IrpK7C8jojcwgu5m2dGFYyX2How0y/vvnN8dpHfeBcHNQgAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Find GitHub users by username, real name, or other profile information. Useful for locating developers, contributors, or team members.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "order": {
+          "type": "string",
+          "description": "Sort order",
+          "enum": [
+            "asc",
+            "desc"
+          ]
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (min 1)",
+          "minimum": 1
+        },
+        "perPage": {
+          "type": "number",
+          "description": "Results per page for pagination (min 1, max 100)",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "query": {
+          "type": "string",
+          "description": "User search query. Examples: 'john smith', 'location:seattle', 'followers:>100'. Search is automatically scoped to type:user."
+        },
+        "sort": {
+          "type": "string",
+          "description": "Sort users by number of followers or repositories, or when the person joined GitHub.",
+          "enum": [
+            "followers",
+            "repositories",
+            "joined"
+          ]
+        }
+      },
+      "required": [
+        "query"
+      ]
+    },
+    "annotations": {
+      "title": "Search users",
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "sub_issue_write",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAC2UlEQVRIicWVMUyTaRjHf/+vVUpOJOdilOYoUvVreq2CDmLOwdlAS5xMbrrhBifjYG7QjYuJw108nZx1huLgYlw0QshxChUK2koxHHcuCmgsFfieG0or3kGPSoz/8X3f5/97nvfN8z7wmaVqm9FodFfR/EnMugy5giCAwYwgI9Ff9Hl9L9Lp1zUBgsGO+rqGwnlhF4CdwBSyAUwvS1G220zHBSFgHtmVxYWvfp2ZGSj8LyAcjgfZphTQZtAr7OdsZvSP9RIJR+LtQhcNusF+d1aUfPp05M8NAavmg8AOk3cmN56+s1Hpa7U/cviUYbcw3jgex9ZCKoBgsKM+0PDuAdBq2He5zOiTzZiXtc+NxRw598GeLRcWTuTz+UUAp3ygrqFwHmgzeWdqNQd4PpFOy/gedNQfaDz3UQXRaHRX0fNPGdzNZUZO12q+VuHIoV7g5Hu/1/IinX7tABTNnwR2SvRsxRzAzOsBGuuWfAkoX5FZFzCVHR95tFVAbiI9DEwj6wLwl5YVMTRYLTDsxjuRrgGYYz/kxkbvbXRWMOBB24cKYI9ks1X8hXQDaAaa5XG9WjImZgV71wI+m8qAv8y0t1pSmP0ITANTmHO2qqvRZDALlTdgHKyjWkx2YvQ2cHtTacMxYBhWK5DoF4TCkXj7Jg02VKsbOwI0Y+qvALZrOQXMC13cKkDSJWBuJUCqAhgbG3uF7IpBcn/k8KlPNQ+78U5QQuhy/vHjuQoAYPndwi9gw4bd2ufGYrWatxz8No50ExhaKsz9Vl6vAPL5/KKzoiTGG0fOg1oqCbvxTp/juw/M+zynu/yTwjoD58CBQ02ez/pAR4E+M69ntf3/o1Y3dqR050oAQz7P6Z6cfPRRw647MkOhUMAfaDyH+AloBKYNPRT292rQHoMOSp09J3TZlt5ezWazxX97VR3638RiX9ct+RImSyBcrDT0ETMyMp4ptRIgVX7QL6J/ALSUEwJ5rdg2AAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABxElEQVRIibWVvW4TURCFv0vlNEDcIHAkKAERJOIKSjoUArwBPwUFFaKIIngAJARCPIgdh4cgRBYt6ZIAEYEqdhpEw0fhCbkKa68dxyNtsfNzzpnZu3NhwpYGBdUqcA+4A1wEZiK0DawD74FWSml3JAJ1CngGLAIngU1gFfgZKWeAG8AFoAu8At6mlH6VtqTOqJ/UP2pDnRuQO6c27VlbrQ0Dvq121Fulag7q5qPmW18SdSqUd9Qrw4Jn9bNR21YrRQkvYixDKy/AuB3jWjocqKpdtXFU8AxrOTqZzp2PgvnaMRDUA+tB7mypG+OCZ3hbahPgRPguAR9LihaicEu9WcKxClzOi/fU1wPAk7rjgX0uEfNG3cs7mJjtE+wA5/olpZQEHgNf6K2NJyW4NeD7v7c4WptjSc0svlMjdzyM2fbdOyOA7x/T+7mzGj9H8xgIWuquevpw4HmsivkxwBdC/WJRsBKLqqPOHgH8aqybtcJlF0m1WLndUToJ5V31q9r3NOYk7Wh1Wa0PyK3HzA3l/4H3uzIrwFNgCThF7/x/AH5EylngOnAe6AAvgXcppd9DEWRE08DdeIou/RVgJaXUGYQzUfsL+zmwV7BtIq0AAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Add a sub-issue to a parent issue in a GitHub repository.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "after_id": {
+          "type": "number",
+          "description": "The ID of the sub-issue to be prioritized after (either after_id OR before_id should be specified)"
+        },
+        "before_id": {
+          "type": "number",
+          "description": "The ID of the sub-issue to be prioritized before (either after_id OR before_id should be specified)"
+        },
+        "issue_number": {
+          "type": "number",
+          "description": "The number of the parent issue"
+        },
+        "method": {
+          "type": "string",
+          "description": "The action to perform on a single sub-issue\nOptions are:\n- 'add' - add a sub-issue to a parent issue in a GitHub repository.\n- 'remove' - remove a sub-issue from a parent issue in a GitHub repository.\n- 'reprioritize' - change the order of sub-issues within a parent issue in a GitHub repository. Use either 'after_id' or 'before_id' to specify the new position.\n\t\t\t\t"
+        },
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "replace_parent": {
+          "type": "boolean",
+          "description": "When true, replaces the sub-issue's current parent issue. Use with 'add' method only."
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        },
+        "sub_issue_id": {
+          "type": "number",
+          "description": "The ID of the sub-issue to add. ID is not the same as issue number"
+        }
+      },
+      "required": [
+        "method",
+        "owner",
+        "repo",
+        "issue_number",
+        "sub_issue_id"
+      ]
+    },
+    "annotations": {
+      "title": "Change sub-issue"
+    }
+  },
+  {
+    "name": "update_pull_request",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACwUlEQVRIie2Vz28UZRjHP993pi0QIC3YahNjirtmd3bS3Q1eUHvQEPUiEv8A4kXjwRJ78MCFBLjBBRKCHowHE38cNCbGGx6IUoKiodtNpoNmTJp4oSJNQ3pw29l5POxus2wo3QTwxPc0887zfD7zvu9kXnjEUfdNrjj5vJOmMP4e9JrfR1G02tuQD8tvgpck0dxCPwK30ViqnJTcr4bOmfRlI/PrhUJ5313woDpDpu8ss7f6nYHrvDnGcYlPsoY/bKaXwHY3HWfvgmNnMX0zvMM7069A3c3pkEYWa7UVgFxQPSfs7SSeH3k2rEy5jMubMBoG1yQ+SBbm53of+gCybMkk/H8VAFdbZisZLAFsJ11oyL+BUURcwrjWAZixXeIwxs/5UuVAr0QAYRjubGR+HWy3mb6QCIBXQe8nce0jgIkwfMo3/xLG085x8I9ofkMyUa0O+w2rgS0mcf3lboEDiKJo1cvsIDDr4D1DhTb8407hYhTdTJW+AvrdMnuhG9Je1m9BBzbfjXbyQcXypeqJLQt7+0rVE/mgYr3j7l7FDzOPBY8FDx6vc1EolPeNjI5/Jpgw7Lm9o+Pry//c/K0PhnLFyrSMDxE79jwxvn9079gvt28vrUD7V1EoFHalbltd2C7DfS4sAF4DTSdx7cL96LliZVriPPADuL+geRh0Z8il5SiKVn2ATENvCCYw78U/b8xdBcgHlYuGHQXuK5A4ClxM4vnXW8Lqp5JdWWt6h4CvWnsgxgDSbRZ3Gg0tCJ7sY4nGwDZOt/WBZtzN9FswLgM2sGann5mcPDaw5pWEHQH7cUu86SdkR3LF6tfrA814MNVpwNrM1leUxPXrSKfMeHcwdctyNotY8c3NbMX3LJsB3ZHsymDqlkHvYHYyievXWxPpSj4o75eYIuPWZof+vRKG4c61pncIx6gZsx34/5L/ACy3ElqUYhuvAAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABn0lEQVRIie2Vvy5EURDGvyMUkhUU/pS2Q2clwvIKqL0Cm9ArrBcQShJPoLFR2YaIhIjQ7a7E39IiCgqVn8KsPY697E3oTHPumTPf990z986M9Mfm/A0wKGlMUlnSlnPuOQQAE5LOnXOFWErAIvBK1S6BZBAzZ2fzcckHjXwVaAXSwD2wWYN8A2iKK1ABt3m+ZeDRnseIthdgDxioxd1o662tfZIO7Lnf8xcklST1StqRdORxNEualHQIDDvnTmvdIGE5vwdWgLy93bQX0w0UgSdgKMC3AdfA7ndpSgKbduUbYBoI/7Ju4BiYrYFfAl4iBbxAgOyPgV9xWYDQ3xCXKK79C/wL/KJZoeW8QpsJCy0C54AMULaGmQu7sIAW4MpaxTKwbQU3U4dAxmLzwLpxXAIJP2jKgkY8Xx4o1SFwBmx7+7RxTUnVb9Bpa9HDFiR1/SRgWH+6FT3/h2qK6sBpB0aBB7yB880NcpaWtGHXjCsVBmb5PDIvgJ46BJKW84q9AguV87Adp/Q+9O8UMfQjRBKSxiV1SNp3zp3Ug/sVewPruexhKwhGXQAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Update an existing pull request in a GitHub repository.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "base": {
+          "type": "string",
+          "description": "New base branch name"
+        },
+        "body": {
+          "type": "string",
+          "description": "New description"
+        },
+        "draft": {
+          "type": "boolean",
+          "description": "Mark pull request as draft (true) or ready for review (false)"
+        },
+        "maintainer_can_modify": {
+          "type": "boolean",
+          "description": "Allow maintainer edits"
+        },
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "pullNumber": {
+          "type": "number",
+          "description": "Pull request number to update"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        },
+        "reviewers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "GitHub usernames to request reviews from"
+        },
+        "state": {
+          "type": "string",
+          "description": "New state",
+          "enum": [
+            "open",
+            "closed"
+          ]
+        },
+        "title": {
+          "type": "string",
+          "description": "New title"
+        }
+      },
+      "required": [
+        "owner",
+        "repo",
+        "pullNumber"
+      ]
+    },
+    "annotations": {
+      "title": "Edit pull request"
+    }
+  },
+  {
+    "name": "update_pull_request_branch",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACwUlEQVRIie2Vz28UZRjHP993pi0QIC3YahNjirtmd3bS3Q1eUHvQEPUiEv8A4kXjwRJ78MCFBLjBBRKCHowHE38cNCbGGx6IUoKiodtNpoNmTJp4oSJNQ3pw29l5POxus2wo3QTwxPc0887zfD7zvu9kXnjEUfdNrjj5vJOmMP4e9JrfR1G02tuQD8tvgpck0dxCPwK30ViqnJTcr4bOmfRlI/PrhUJ5313woDpDpu8ss7f6nYHrvDnGcYlPsoY/bKaXwHY3HWfvgmNnMX0zvMM7069A3c3pkEYWa7UVgFxQPSfs7SSeH3k2rEy5jMubMBoG1yQ+SBbm53of+gCybMkk/H8VAFdbZisZLAFsJ11oyL+BUURcwrjWAZixXeIwxs/5UuVAr0QAYRjubGR+HWy3mb6QCIBXQe8nce0jgIkwfMo3/xLG085x8I9ofkMyUa0O+w2rgS0mcf3lboEDiKJo1cvsIDDr4D1DhTb8407hYhTdTJW+AvrdMnuhG9Je1m9BBzbfjXbyQcXypeqJLQt7+0rVE/mgYr3j7l7FDzOPBY8FDx6vc1EolPeNjI5/Jpgw7Lm9o+Pry//c/K0PhnLFyrSMDxE79jwxvn9079gvt28vrUD7V1EoFHalbltd2C7DfS4sAF4DTSdx7cL96LliZVriPPADuL+geRh0Z8il5SiKVn2ATENvCCYw78U/b8xdBcgHlYuGHQXuK5A4ClxM4vnXW8Lqp5JdWWt6h4CvWnsgxgDSbRZ3Gg0tCJ7sY4nGwDZOt/WBZtzN9FswLgM2sGann5mcPDaw5pWEHQH7cUu86SdkR3LF6tfrA814MNVpwNrM1leUxPXrSKfMeHcwdctyNotY8c3NbMX3LJsB3ZHsymDqlkHvYHYyievXWxPpSj4o75eYIuPWZof+vRKG4c61pncIx6gZsx34/5L/ACy3ElqUYhuvAAAAAElFTkSuQmCC",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAABn0lEQVRIie2Vvy5EURDGvyMUkhUU/pS2Q2clwvIKqL0Cm9ArrBcQShJPoLFR2YaIhIjQ7a7E39IiCgqVn8KsPY697E3oTHPumTPf990z986M9Mfm/A0wKGlMUlnSlnPuOQQAE5LOnXOFWErAIvBK1S6BZBAzZ2fzcckHjXwVaAXSwD2wWYN8A2iKK1ABt3m+ZeDRnseIthdgDxioxd1o662tfZIO7Lnf8xcklST1StqRdORxNEualHQIDDvnTmvdIGE5vwdWgLy93bQX0w0UgSdgKMC3AdfA7ndpSgKbduUbYBoI/7Ju4BiYrYFfAl4iBbxAgOyPgV9xWYDQ3xCXKK79C/wL/KJZoeW8QpsJCy0C54AMULaGmQu7sIAW4MpaxTKwbQU3U4dAxmLzwLpxXAIJP2jKgkY8Xx4o1SFwBmx7+7RxTUnVb9Bpa9HDFiR1/SRgWH+6FT3/h2qK6sBpB0aBB7yB880NcpaWtGHXjCsVBmb5PDIvgJ46BJKW84q9AguV87Adp/Q+9O8UMfQjRBKSxiV1SNp3zp3Ug/sVewPruexhKwhGXQAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Update the branch of a pull request with the latest changes from the base branch.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "expectedHeadSha": {
+          "type": "string",
+          "description": "The expected SHA of the pull request's HEAD ref"
+        },
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "pullNumber": {
+          "type": "number",
+          "description": "Pull request number"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        }
+      },
+      "required": [
+        "owner",
+        "repo",
+        "pullNumber"
+      ]
+    },
+    "annotations": {
+      "title": "Update pull request branch"
+    }
+  }
+]

--- a/generated/github-mcp/capture/raw-tools-list.json
+++ b/generated/github-mcp/capture/raw-tools-list.json
@@ -1858,6 +1858,54 @@
     }
   },
   {
+    "name": "run_secret_scanning",
+    "icons": [
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAAC20lEQVRIidWUS4wMURSGv3O7kWmPEMRrSMzcbl1dpqtmGuOxsCKECCKxEBusSJhIWEhsWLFAbC1sWFiISBARCyQ2kzSZGaMxHokgXvGIiMH0PRZjpJqqHpb+TeX+59z//H/q5sD/DqlX9H1/zFeX2qzIKoFWYDKgwBtUymL0UkNaT3V3d3/+5wG2EGxB9TDIxGFMvhVhb9/drpN/NaDJC7MGdwJk6TDCv0Gvq0lve9R762GUNdFDLleaZNBrICGq+4yhvf9TJtP/KZNB2PrLlbBliBfRhajuAwnFVa/n8/nkxFkv3GO9oJrzgwVxdesV71ov6I2r5fxggfWCatYL9yYmUJgLPH7Q29WZ4OED6Me4wuAdeQK6MMqna9t0GuibBHFAmgZ9JMG9BhkXZWoSCDSATIq7aguBD0wBplq/tZBgYDIwKnZAs99mFRYD9vd/YK0dpcqhobM6d9haWyOULRTbAauwuNlvsxHTYP3iBnVyXGAa8BIYC3oVeAKioCtAPEE7FCOgR0ErIJdBBZgNskzh40+NF6K6s+9e91lp9osrxMnFoTSmSmPVsF+E5cB0YEDgtoMjjypd5wCy+WC9GnajhEAa4bkqV9LOHKwa9/yneYeyUqwX3AdyQ5EeVrrqro/hYL0g+ggemKh4HGbPmVu0+fB8U76lpR6XgJwZpoGUpNYiusZg1tXjkmCAav0OMTXfJC4eVYPqwbot6l4BCPqyLhd7lwMAWC/cYb3gi/UCzRaKOxsbFzVEM1iv2Ebt5v2Dm14qZbJecZf1Ah3UCrcTbbB+awHnjgHLgHeinHYqZ8aPSXWWy+XvcQZLpdKI9/0D7UbZiLIJmABckVSqo+/OrUrNgF+D8q1LEdcBrAJGAJ8ROlGeicorABWdAswE5gOjge8CF8Ad66v03IjqJb75WS0tE0YOmNWqLBGReaAzgIkMLrt3oM9UpSzCzW9pd+FpT8/7JK3/Gz8Ao5X6wtwP7N4AAAAASUVORK5CYII=",
+        "mimeType": "image/png",
+        "theme": "light"
+      },
+      {
+        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABmJLR0QA/wD/AP+gvaeTAAACCElEQVRIid2UPWsUYRSFn3dxWWJUkESiBgslFokfhehGiGClBBQx4h9IGlEh2ijYxh+gxEL/hIWwhYpF8KNZsFRJYdJEiUbjCkqisj4W+y6Mk5nd1U4PDMOce+45L3fmDvzXUDeo59WK+kb9rn5TF9R76jm1+2/NJ9QPtseSOv4nxrvVmQ6M05hRB9qZ98ZR1NRralntitdEwmw8wQ9HbS329rQKuKLW1XJO/aX6IqdWjr1Xk/y6lG4vMBdCqOacoZZ3uBBCVZ0HDrcK2AYs5ZkAuwBb1N8Dm5JEISXoAnqzOtU9QB+wVR3KCdgClDIr6kCc4c/0O1BLNnahiYpaSmmGY62e/JpCLJ4FpmmMaBHYCDwC5mmMZBQYBC7HnhvAK+B+fN4JHAM+R4+3wGQI4S7qaExtol+9o86pq+oX9Yk6ljjtGfVprK2qr9Xb6vaET109jjqb3Jac2XaM1PLNpok1Aep+G/+dfa24nADTX1EWTgOngLE2XCYKQL0DTfKex2WhXgCutxG9i/fFNlwWpgBQL6orcWyTaldToRbUA2pow61XL0WPFfXCb1HqkPowCj6q0+qIWsw7nlpUj6i31OXY+0AdbGpCRtNRGgt1AigCX4EqsJAYTR+wAzgEdAM/gApwM4TwOOm3JiARtBk4CYwAB4F+oIfGZi/HwOfAM6ASQviU5/Vv4xcBzmW2eT1nrQAAAABJRU5ErkJggg==",
+        "mimeType": "image/png",
+        "theme": "dark"
+      }
+    ],
+    "description": "Scan files, content, or recent changes for secrets such as API keys, passwords, tokens, and credentials.\n\nThis tool is intended for targeted scans of specific files, snippets, or diffs provided directly as content. It accepts file contents or diffs and returns detected secrets with their locations and related secret scanning metadata. Content must not be empty. For full repository scanning, other mechanisms are available.\n\nCaveats:\n\n- Only files within the codebase should be scanned. Files outside of the codebase should not be sent.\n- Files listed in .gitignore should be skipped.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Array of file contents, snippets, or diff hunks to scan for secrets. These must be raw contents, not repository file paths.",
+          "minItems": 1,
+          "maxItems": 100
+        },
+        "owner": {
+          "type": "string",
+          "description": "Repository owner"
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository name"
+        }
+      },
+      "required": [
+        "files",
+        "owner",
+        "repo"
+      ]
+    },
+    "annotations": {
+      "title": "Run Secret Scanning",
+      "readOnlyHint": true,
+      "openWorldHint": false
+    }
+  },
+  {
     "name": "search_code",
     "icons": [
       {

--- a/generated/github-mcp/capture/warnings.json
+++ b/generated/github-mcp/capture/warnings.json
@@ -1,0 +1,291 @@
+[
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'pullNumber' was normalized to 'pull_number'.",
+    "tool": "add_comment_to_pending_review",
+    "field": "pullNumber",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'startLine' was normalized to 'start_line'.",
+    "tool": "add_comment_to_pending_review",
+    "field": "startLine",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'startSide' was normalized to 'start_side'.",
+    "tool": "add_comment_to_pending_review",
+    "field": "startSide",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'subjectType' was normalized to 'subject_type'.",
+    "tool": "add_comment_to_pending_review",
+    "field": "subjectType",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'commentId' was normalized to 'comment_id'.",
+    "tool": "add_reply_to_pull_request_comment",
+    "field": "commentId",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'pullNumber' was normalized to 'pull_number'.",
+    "tool": "add_reply_to_pull_request_comment",
+    "field": "pullNumber",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "REVIEW_REQUIRED",
+    "severity": "warning",
+    "message": "Tool name spans both create and update semantics.",
+    "tool": "create_or_update_file",
+    "heuristic": "endpoint_classification"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'autoInit' was normalized to 'auto_init'.",
+    "tool": "create_repository",
+    "field": "autoInit",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'perPage' was normalized to 'per_page'.",
+    "tool": "get_commit",
+    "field": "perPage",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'perPage' was normalized to 'per_page'.",
+    "tool": "issue_read",
+    "field": "perPage",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "REVIEW_REQUIRED",
+    "severity": "info",
+    "message": "Write suffix is semantically broad and may hide create/update behavior.",
+    "tool": "issue_write",
+    "heuristic": "endpoint_classification"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'perPage' was normalized to 'per_page'.",
+    "tool": "list_branches",
+    "field": "perPage",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'perPage' was normalized to 'per_page'.",
+    "tool": "list_commits",
+    "field": "perPage",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'orderBy' was normalized to 'order_by'.",
+    "tool": "list_issues",
+    "field": "orderBy",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'perPage' was normalized to 'per_page'.",
+    "tool": "list_issues",
+    "field": "perPage",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'perPage' was normalized to 'per_page'.",
+    "tool": "list_pull_requests",
+    "field": "perPage",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'perPage' was normalized to 'per_page'.",
+    "tool": "list_releases",
+    "field": "perPage",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'perPage' was normalized to 'per_page'.",
+    "tool": "list_tags",
+    "field": "perPage",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "REVIEW_REQUIRED",
+    "severity": "info",
+    "message": "Action-oriented tool classified as EXECUTE conservatively.",
+    "tool": "merge_pull_request",
+    "heuristic": "endpoint_classification"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'pullNumber' was normalized to 'pull_number'.",
+    "tool": "merge_pull_request",
+    "field": "pullNumber",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'perPage' was normalized to 'per_page'.",
+    "tool": "pull_request_read",
+    "field": "perPage",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'pullNumber' was normalized to 'pull_number'.",
+    "tool": "pull_request_read",
+    "field": "pullNumber",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "REVIEW_REQUIRED",
+    "severity": "info",
+    "message": "Write suffix is semantically broad and may hide create/update behavior.",
+    "tool": "pull_request_review_write",
+    "heuristic": "endpoint_classification"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'commitID' was normalized to 'commit_id'.",
+    "tool": "pull_request_review_write",
+    "field": "commitID",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'pullNumber' was normalized to 'pull_number'.",
+    "tool": "pull_request_review_write",
+    "field": "pullNumber",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "REVIEW_REQUIRED",
+    "severity": "info",
+    "message": "Action-oriented tool classified as EXECUTE conservatively.",
+    "tool": "push_files",
+    "heuristic": "endpoint_classification"
+  },
+  {
+    "code": "REVIEW_REQUIRED",
+    "severity": "info",
+    "message": "Action-oriented tool classified as EXECUTE conservatively.",
+    "tool": "request_copilot_review",
+    "heuristic": "endpoint_classification"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'pullNumber' was normalized to 'pull_number'.",
+    "tool": "request_copilot_review",
+    "field": "pullNumber",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'perPage' was normalized to 'per_page'.",
+    "tool": "search_code",
+    "field": "perPage",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'perPage' was normalized to 'per_page'.",
+    "tool": "search_issues",
+    "field": "perPage",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'perPage' was normalized to 'per_page'.",
+    "tool": "search_pull_requests",
+    "field": "perPage",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'perPage' was normalized to 'per_page'.",
+    "tool": "search_repositories",
+    "field": "perPage",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'perPage' was normalized to 'per_page'.",
+    "tool": "search_users",
+    "field": "perPage",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "REVIEW_REQUIRED",
+    "severity": "info",
+    "message": "Write suffix is semantically broad and may hide create/update behavior.",
+    "tool": "sub_issue_write",
+    "heuristic": "endpoint_classification"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'pullNumber' was normalized to 'pull_number'.",
+    "tool": "update_pull_request",
+    "field": "pullNumber",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'expectedHeadSha' was normalized to 'expected_head_sha'.",
+    "tool": "update_pull_request_branch",
+    "field": "expectedHeadSha",
+    "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "PARAM_NAME_NORMALIZED",
+    "severity": "info",
+    "message": "Parameter 'pullNumber' was normalized to 'pull_number'.",
+    "tool": "update_pull_request_branch",
+    "field": "pullNumber",
+    "heuristic": "snake_case_normalization"
+  }
+]

--- a/generated/github-mcp/capture/warnings.json
+++ b/generated/github-mcp/capture/warnings.json
@@ -49,6 +49,13 @@
   },
   {
     "code": "REVIEW_REQUIRED",
+    "severity": "info",
+    "message": "Assignment semantics treated as UPDATE on an existing resource.",
+    "tool": "assign_copilot_to_issue",
+    "heuristic": "endpoint_classification"
+  },
+  {
+    "code": "REVIEW_REQUIRED",
     "severity": "warning",
     "message": "Tool name spans both create and update semantics.",
     "tool": "create_or_update_file",
@@ -175,7 +182,7 @@
   {
     "code": "REVIEW_REQUIRED",
     "severity": "info",
-    "message": "Write suffix is semantically broad and may hide create/update behavior.",
+    "message": "Description implies destructive behavior.",
     "tool": "pull_request_review_write",
     "heuristic": "endpoint_classification"
   },
@@ -216,6 +223,13 @@
     "tool": "request_copilot_review",
     "field": "pullNumber",
     "heuristic": "snake_case_normalization"
+  },
+  {
+    "code": "REVIEW_REQUIRED",
+    "severity": "info",
+    "message": "Description implies workflow execution.",
+    "tool": "run_secret_scanning",
+    "heuristic": "endpoint_classification"
   },
   {
     "code": "PARAM_NAME_NORMALIZED",

--- a/generated/github-mcp/schema-overrides.json
+++ b/generated/github-mcp/schema-overrides.json
@@ -21,6 +21,10 @@
     "merge_pull_request": {
       "endpoint": "EXECUTE"
     },
+    "push_files": {
+      "endpoint": "EXECUTE",
+      "review_reason": "push_files can create and update multiple files plus branch history in a single workflow, so the first golden-path adapter keeps it in EXECUTE rather than collapsing it into CREATE or UPDATE."
+    },
     "pull_request_review_write": {
       "endpoint": "UPDATE",
       "review_reason": "Review-write semantics are treated as UPDATE in the first pass."

--- a/generated/github-mcp/schema-overrides.json
+++ b/generated/github-mcp/schema-overrides.json
@@ -1,0 +1,36 @@
+{
+  "adapter": {
+    "name": "github-mcp",
+    "version": "0.1.0",
+    "description": "Generated MCP-AQL adapter for the official GitHub MCP server.",
+    "token_env": "GITHUB_PERSONAL_ACCESS_TOKEN"
+  },
+  "operations": {
+    "create_or_update_file": {
+      "endpoint": "UPDATE",
+      "review_reason": "Mixed create/update semantics mapped to UPDATE for the first generated adapter."
+    },
+    "create_pull_request_with_copilot": {
+      "endpoint": "EXECUTE",
+      "review_reason": "Copilot-assisted pull request creation is treated as workflow execution in the first pass."
+    },
+    "issue_write": {
+      "endpoint": "UPDATE",
+      "review_reason": "issue_write spans create and update behavior; pinned to UPDATE pending finer-grained decomposition."
+    },
+    "merge_pull_request": {
+      "endpoint": "EXECUTE"
+    },
+    "pull_request_review_write": {
+      "endpoint": "UPDATE",
+      "review_reason": "Review-write semantics are treated as UPDATE in the first pass."
+    },
+    "request_copilot_review": {
+      "endpoint": "EXECUTE"
+    },
+    "sub_issue_write": {
+      "endpoint": "UPDATE",
+      "review_reason": "sub_issue_write is treated as UPDATE until the source server exposes narrower tool semantics."
+    }
+  }
+}

--- a/generated/github-mcp/schema/adapter-provenance.json
+++ b/generated/github-mcp/schema/adapter-provenance.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-03-13T19:00:32.194Z",
+  "generated_at": "2026-03-13T20:09:00.840Z",
   "source_server_name": "github-mcp-server",
   "source_server_version": "github-mcp-server/remote-9f836f5fe414b6a085717f480c7f23093404340d",
   "source_capture_name": "github-mcp-remote",
@@ -256,7 +256,8 @@
       "endpoint": "EXECUTE",
       "needs_review": true,
       "review_reasons": [
-        "Action-oriented tool classified as EXECUTE conservatively."
+        "Action-oriented tool classified as EXECUTE conservatively.",
+        "push_files can create and update multiple files plus branch history in a single workflow, so the first golden-path adapter keeps it in EXECUTE rather than collapsing it into CREATE or UPDATE."
       ]
     },
     {

--- a/generated/github-mcp/schema/adapter-provenance.json
+++ b/generated/github-mcp/schema/adapter-provenance.json
@@ -1,0 +1,331 @@
+{
+  "generated_at": "2026-03-13T19:00:32.194Z",
+  "source_server_name": "github-mcp-server",
+  "source_server_version": "github-mcp-server/remote-9f836f5fe414b6a085717f480c7f23093404340d",
+  "source_capture_name": "github-mcp-remote",
+  "warning_count": 37,
+  "operation_count": 43,
+  "operations": [
+    {
+      "source_tool_name": "add_comment_to_pending_review",
+      "operation_name": "add_comment_to_pending_review",
+      "endpoint": "CREATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "add_issue_comment",
+      "operation_name": "add_issue_comment",
+      "endpoint": "CREATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "add_reply_to_pull_request_comment",
+      "operation_name": "add_reply_to_pull_request_comment",
+      "endpoint": "CREATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "assign_copilot_to_issue",
+      "operation_name": "assign_copilot_to_issue",
+      "endpoint": "CREATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "create_branch",
+      "operation_name": "create_branch",
+      "endpoint": "CREATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "create_or_update_file",
+      "operation_name": "create_or_update_file",
+      "endpoint": "UPDATE",
+      "needs_review": true,
+      "review_reasons": [
+        "Tool name spans both create and update semantics.",
+        "Mixed create/update semantics mapped to UPDATE for the first generated adapter."
+      ]
+    },
+    {
+      "source_tool_name": "create_pull_request",
+      "operation_name": "create_pull_request",
+      "endpoint": "CREATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "create_pull_request_with_copilot",
+      "operation_name": "create_pull_request_with_copilot",
+      "endpoint": "EXECUTE",
+      "needs_review": false,
+      "review_reasons": [
+        "Copilot-assisted pull request creation is treated as workflow execution in the first pass."
+      ]
+    },
+    {
+      "source_tool_name": "create_repository",
+      "operation_name": "create_repository",
+      "endpoint": "CREATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "delete_file",
+      "operation_name": "delete_file",
+      "endpoint": "DELETE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "fork_repository",
+      "operation_name": "fork_repository",
+      "endpoint": "CREATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_commit",
+      "operation_name": "get_commit",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_copilot_job_status",
+      "operation_name": "get_copilot_job_status",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_file_contents",
+      "operation_name": "get_file_contents",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_label",
+      "operation_name": "get_label",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_latest_release",
+      "operation_name": "get_latest_release",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_me",
+      "operation_name": "get_me",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_release_by_tag",
+      "operation_name": "get_release_by_tag",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_tag",
+      "operation_name": "get_tag",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_team_members",
+      "operation_name": "get_team_members",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_teams",
+      "operation_name": "get_teams",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "issue_read",
+      "operation_name": "issue_read",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "issue_write",
+      "operation_name": "issue_write",
+      "endpoint": "UPDATE",
+      "needs_review": true,
+      "review_reasons": [
+        "Write suffix is semantically broad and may hide create/update behavior.",
+        "issue_write spans create and update behavior; pinned to UPDATE pending finer-grained decomposition."
+      ]
+    },
+    {
+      "source_tool_name": "list_branches",
+      "operation_name": "list_branches",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "list_commits",
+      "operation_name": "list_commits",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "list_issue_types",
+      "operation_name": "list_issue_types",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "list_issues",
+      "operation_name": "list_issues",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "list_pull_requests",
+      "operation_name": "list_pull_requests",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "list_releases",
+      "operation_name": "list_releases",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "list_tags",
+      "operation_name": "list_tags",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "merge_pull_request",
+      "operation_name": "merge_pull_request",
+      "endpoint": "EXECUTE",
+      "needs_review": true,
+      "review_reasons": [
+        "Action-oriented tool classified as EXECUTE conservatively."
+      ]
+    },
+    {
+      "source_tool_name": "pull_request_read",
+      "operation_name": "pull_request_read",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "pull_request_review_write",
+      "operation_name": "pull_request_review_write",
+      "endpoint": "UPDATE",
+      "needs_review": true,
+      "review_reasons": [
+        "Write suffix is semantically broad and may hide create/update behavior.",
+        "Review-write semantics are treated as UPDATE in the first pass."
+      ]
+    },
+    {
+      "source_tool_name": "push_files",
+      "operation_name": "push_files",
+      "endpoint": "EXECUTE",
+      "needs_review": true,
+      "review_reasons": [
+        "Action-oriented tool classified as EXECUTE conservatively."
+      ]
+    },
+    {
+      "source_tool_name": "request_copilot_review",
+      "operation_name": "request_copilot_review",
+      "endpoint": "EXECUTE",
+      "needs_review": true,
+      "review_reasons": [
+        "Action-oriented tool classified as EXECUTE conservatively."
+      ]
+    },
+    {
+      "source_tool_name": "search_code",
+      "operation_name": "search_code",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "search_issues",
+      "operation_name": "search_issues",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "search_pull_requests",
+      "operation_name": "search_pull_requests",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "search_repositories",
+      "operation_name": "search_repositories",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "search_users",
+      "operation_name": "search_users",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "sub_issue_write",
+      "operation_name": "sub_issue_write",
+      "endpoint": "UPDATE",
+      "needs_review": true,
+      "review_reasons": [
+        "Write suffix is semantically broad and may hide create/update behavior.",
+        "sub_issue_write is treated as UPDATE until the source server exposes narrower tool semantics."
+      ]
+    },
+    {
+      "source_tool_name": "update_pull_request",
+      "operation_name": "update_pull_request",
+      "endpoint": "UPDATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "update_pull_request_branch",
+      "operation_name": "update_pull_request_branch",
+      "endpoint": "UPDATE",
+      "needs_review": false,
+      "review_reasons": []
+    }
+  ]
+}

--- a/generated/github-mcp/schema/adapter-provenance.json
+++ b/generated/github-mcp/schema/adapter-provenance.json
@@ -1,10 +1,10 @@
 {
-  "generated_at": "2026-03-13T20:09:00.840Z",
+  "generated_at": "2026-03-19T04:08:34.476Z",
   "source_server_name": "github-mcp-server",
-  "source_server_version": "github-mcp-server/remote-9f836f5fe414b6a085717f480c7f23093404340d",
+  "source_server_version": "github-mcp-server/remote-212864f3b76a000b57f4f4f0435df686fc2bbc66",
   "source_capture_name": "github-mcp-remote",
-  "warning_count": 37,
-  "operation_count": 43,
+  "warning_count": 39,
+  "operation_count": 44,
   "operations": [
     {
       "source_tool_name": "add_comment_to_pending_review",
@@ -30,9 +30,11 @@
     {
       "source_tool_name": "assign_copilot_to_issue",
       "operation_name": "assign_copilot_to_issue",
-      "endpoint": "CREATE",
-      "needs_review": false,
-      "review_reasons": []
+      "endpoint": "UPDATE",
+      "needs_review": true,
+      "review_reasons": [
+        "Assignment semantics treated as UPDATE on an existing resource."
+      ]
     },
     {
       "source_tool_name": "create_branch",
@@ -246,7 +248,7 @@
       "endpoint": "UPDATE",
       "needs_review": true,
       "review_reasons": [
-        "Write suffix is semantically broad and may hide create/update behavior.",
+        "Description implies destructive behavior.",
         "Review-write semantics are treated as UPDATE in the first pass."
       ]
     },
@@ -267,6 +269,15 @@
       "needs_review": true,
       "review_reasons": [
         "Action-oriented tool classified as EXECUTE conservatively."
+      ]
+    },
+    {
+      "source_tool_name": "run_secret_scanning",
+      "operation_name": "run_secret_scanning",
+      "endpoint": "EXECUTE",
+      "needs_review": true,
+      "review_reasons": [
+        "Description implies workflow execution."
       ]
     },
     {

--- a/generated/github-mcp/schema/adapter-schema.json
+++ b/generated/github-mcp/schema/adapter-schema.json
@@ -1,0 +1,1835 @@
+{
+  "name": "github-mcp",
+  "type": "adapter",
+  "version": "0.1.0",
+  "description": "Generated MCP-AQL adapter for the official GitHub MCP server.",
+  "target": {
+    "base_url": "https://api.githubcopilot.com/mcp",
+    "transport": "http",
+    "protocol": "custom",
+    "serialization": "json"
+  },
+  "auth": {
+    "type": "bearer",
+    "header": "Authorization",
+    "prefix": "Bearer ",
+    "token_env": "GITHUB_PERSONAL_ACCESS_TOKEN"
+  },
+  "operations": {
+    "read": [
+      {
+        "name": "get_commit",
+        "maps_to": "tool:get_commit",
+        "description": "Get details for a commit from a GitHub repository",
+        "params": {
+          "include_diff": {
+            "type": "boolean",
+            "description": "Whether to include file diffs and stats in the response. Default is true.",
+            "default": true
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "sha": {
+            "type": "string",
+            "required": true,
+            "description": "Commit SHA, branch name, or tag name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "get_copilot_job_status",
+        "maps_to": "tool:get_copilot_job_status",
+        "description": "Get the status of a GitHub Copilot coding agent job. Use this to check if a previously submitted task has completed and to get the pull request URL once it's created. Provide the job ID (from create_pull_request_with_copilot) or pull request number (from assign_copilot_to_issue), or any pull request you want agent sessions for.",
+        "params": {
+          "id": {
+            "type": "string",
+            "required": true,
+            "description": "Job ID or pull request number"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "get_file_contents",
+        "maps_to": "tool:get_file_contents",
+        "description": "Get the contents of a file or directory from a GitHub repository",
+        "params": {
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner (username or organization)"
+          },
+          "path": {
+            "type": "string",
+            "description": "Path to file/directory",
+            "default": "/"
+          },
+          "ref": {
+            "type": "string",
+            "description": "Accepts optional git refs such as `refs/tags/{tag}`, `refs/heads/{branch}` or `refs/pull/{pr_number}/head`"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "sha": {
+            "type": "string",
+            "description": "Accepts optional commit SHA. If specified, it will be used instead of ref"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "get_label",
+        "maps_to": "tool:get_label",
+        "description": "Get a specific label from a repository.",
+        "params": {
+          "name": {
+            "type": "string",
+            "required": true,
+            "description": "Label name."
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner (username or organization name)"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "get_latest_release",
+        "maps_to": "tool:get_latest_release",
+        "description": "Get the latest release in a GitHub repository",
+        "params": {
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "get_me",
+        "maps_to": "tool:get_me",
+        "description": "Get details of the authenticated GitHub user. Use this when a request is about the user's own profile for GitHub. Or when information is missing to build other tool calls.",
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "get_release_by_tag",
+        "maps_to": "tool:get_release_by_tag",
+        "description": "Get a specific release by its tag name in a GitHub repository",
+        "params": {
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "tag": {
+            "type": "string",
+            "required": true,
+            "description": "Tag name (e.g., 'v1.0.0')"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "get_tag",
+        "maps_to": "tool:get_tag",
+        "description": "Get details about a specific git tag in a GitHub repository",
+        "params": {
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "tag": {
+            "type": "string",
+            "required": true,
+            "description": "Tag name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "get_team_members",
+        "maps_to": "tool:get_team_members",
+        "description": "Get member usernames of a specific team in an organization. Limited to organizations accessible with current credentials",
+        "params": {
+          "org": {
+            "type": "string",
+            "required": true,
+            "description": "Organization login (owner) that contains the team."
+          },
+          "team_slug": {
+            "type": "string",
+            "required": true,
+            "description": "Team slug"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "get_teams",
+        "maps_to": "tool:get_teams",
+        "description": "Get details of the teams the user is a member of. Limited to organizations accessible with current credentials",
+        "params": {
+          "user": {
+            "type": "string",
+            "description": "Username to get teams for. If not provided, uses the authenticated user."
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "issue_read",
+        "maps_to": "tool:issue_read",
+        "description": "Get information about a specific issue in a GitHub repository.",
+        "params": {
+          "issue_number": {
+            "type": "number",
+            "required": true,
+            "description": "The number of the issue"
+          },
+          "method": {
+            "type": "string",
+            "required": true,
+            "description": "The read operation to perform on a single issue.\nOptions are:\n1. get - Get details of a specific issue.\n2. get_comments - Get issue comments.\n3. get_sub_issues - Get sub-issues of the issue.\n4. get_labels - Get labels assigned to the issue.\n",
+            "enum": [
+              "get",
+              "get_comments",
+              "get_sub_issues",
+              "get_labels"
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "The owner of the repository"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "The name of the repository"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "list_branches",
+        "maps_to": "tool:list_branches",
+        "description": "List branches in a GitHub repository",
+        "params": {
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "list_commits",
+        "maps_to": "tool:list_commits",
+        "description": "Get list of commits of a branch in a GitHub repository. Returns at least 30 results per page by default, but can return more if specified using the perPage parameter (up to 100).",
+        "params": {
+          "author": {
+            "type": "string",
+            "description": "Author username or email address to filter commits by"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "sha": {
+            "type": "string",
+            "description": "Commit SHA, branch or tag name to list commits of. If not provided, uses the default branch of the repository. If a commit SHA is provided, will list commits up to that SHA."
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "list_issue_types",
+        "maps_to": "tool:list_issue_types",
+        "description": "List supported issue types for repository owner (organization).",
+        "params": {
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "The organization owner of the repository"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "list_issues",
+        "maps_to": "tool:list_issues",
+        "description": "List issues in a GitHub repository. For pagination, use the 'endCursor' from the previous response's 'pageInfo' in the 'after' parameter.",
+        "params": {
+          "after": {
+            "type": "string",
+            "description": "Cursor for pagination. Use the endCursor from the previous page's PageInfo for GraphQL APIs."
+          },
+          "direction": {
+            "type": "string",
+            "description": "Order direction. If provided, the 'orderBy' also needs to be provided.",
+            "enum": [
+              "ASC",
+              "DESC"
+            ]
+          },
+          "labels": {
+            "type": "array",
+            "description": "Filter by labels"
+          },
+          "order_by": {
+            "type": "string",
+            "description": "Order issues by field. If provided, the 'direction' also needs to be provided.",
+            "enum": [
+              "CREATED_AT",
+              "UPDATED_AT",
+              "COMMENTS"
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "since": {
+            "type": "string",
+            "description": "Filter by date (ISO 8601 timestamp)"
+          },
+          "state": {
+            "type": "string",
+            "description": "Filter by state, by default both open and closed issues are returned when not provided",
+            "enum": [
+              "OPEN",
+              "CLOSED"
+            ]
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "list_pull_requests",
+        "maps_to": "tool:list_pull_requests",
+        "description": "List pull requests in a GitHub repository. If the user specifies an author, then DO NOT use this tool and use the search_pull_requests tool instead.",
+        "params": {
+          "base": {
+            "type": "string",
+            "description": "Filter by base branch"
+          },
+          "direction": {
+            "type": "string",
+            "description": "Sort direction",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "head": {
+            "type": "string",
+            "description": "Filter by head user/org and branch"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "sort": {
+            "type": "string",
+            "description": "Sort by",
+            "enum": [
+              "created",
+              "updated",
+              "popularity",
+              "long-running"
+            ]
+          },
+          "state": {
+            "type": "string",
+            "description": "Filter by state",
+            "enum": [
+              "open",
+              "closed",
+              "all"
+            ]
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "list_releases",
+        "maps_to": "tool:list_releases",
+        "description": "List releases in a GitHub repository",
+        "params": {
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "list_tags",
+        "maps_to": "tool:list_tags",
+        "description": "List git tags in a GitHub repository",
+        "params": {
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "pull_request_read",
+        "maps_to": "tool:pull_request_read",
+        "description": "Get information on a specific pull request in GitHub repository.",
+        "params": {
+          "method": {
+            "type": "string",
+            "required": true,
+            "description": "Action to specify what pull request data needs to be retrieved from GitHub. \nPossible options: \n 1. get - Get details of a specific pull request.\n 2. get_diff - Get the diff of a pull request.\n 3. get_status - Get combined commit status of a head commit in a pull request.\n 4. get_files - Get the list of files changed in a pull request. Use with pagination parameters to control the number of results returned.\n 5. get_review_comments - Get review threads on a pull request. Each thread contains logically grouped review comments made on the same code location during pull request reviews. Returns threads with metadata (isResolved, isOutdated, isCollapsed) and their associated comments. Use cursor-based pagination (perPage, after) to control results.\n 6. get_reviews - Get the reviews on a pull request. When asked for review comments, use get_review_comments method.\n 7. get_comments - Get comments on a pull request. Use this if user doesn't specifically want review comments. Use with pagination parameters to control the number of results returned.\n 8. get_check_runs - Get check runs for the head commit of a pull request. Check runs are the individual CI/CD jobs and checks that run on the PR.\n",
+            "enum": [
+              "get",
+              "get_diff",
+              "get_status",
+              "get_files",
+              "get_review_comments",
+              "get_reviews",
+              "get_comments",
+              "get_check_runs"
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "pull_number": {
+            "type": "number",
+            "required": true,
+            "description": "Pull request number"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "search_code",
+        "maps_to": "tool:search_code",
+        "description": "Fast and precise code search across ALL GitHub repositories using GitHub's native search engine. Best for finding exact symbols, functions, classes, or specific code patterns.",
+        "params": {
+          "order": {
+            "type": "string",
+            "description": "Sort order for results",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "query": {
+            "type": "string",
+            "required": true,
+            "description": "Search query using GitHub's powerful code search syntax. Examples: 'content:Skill language:Java org:github', 'NOT is:archived language:Python OR language:go', 'repo:github/github-mcp-server'. Supports exact matching, language filters, path filters, and more."
+          },
+          "sort": {
+            "type": "string",
+            "description": "Sort field ('indexed' only)"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "search_issues",
+        "maps_to": "tool:search_issues",
+        "description": "Search for issues in GitHub repositories using issues search syntax already scoped to is:issue",
+        "params": {
+          "order": {
+            "type": "string",
+            "description": "Sort order",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "description": "Optional repository owner. If provided with repo, only issues for this repository are listed."
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "query": {
+            "type": "string",
+            "required": true,
+            "description": "Search query using GitHub issues search syntax"
+          },
+          "repo": {
+            "type": "string",
+            "description": "Optional repository name. If provided with owner, only issues for this repository are listed."
+          },
+          "sort": {
+            "type": "string",
+            "description": "Sort field by number of matches of categories, defaults to best match",
+            "enum": [
+              "comments",
+              "reactions",
+              "reactions-+1",
+              "reactions--1",
+              "reactions-smile",
+              "reactions-thinking_face",
+              "reactions-heart",
+              "reactions-tada",
+              "interactions",
+              "created",
+              "updated"
+            ]
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "search_pull_requests",
+        "maps_to": "tool:search_pull_requests",
+        "description": "Search for pull requests in GitHub repositories using issues search syntax already scoped to is:pr",
+        "params": {
+          "order": {
+            "type": "string",
+            "description": "Sort order",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "description": "Optional repository owner. If provided with repo, only pull requests for this repository are listed."
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "query": {
+            "type": "string",
+            "required": true,
+            "description": "Search query using GitHub pull request search syntax"
+          },
+          "repo": {
+            "type": "string",
+            "description": "Optional repository name. If provided with owner, only pull requests for this repository are listed."
+          },
+          "sort": {
+            "type": "string",
+            "description": "Sort field by number of matches of categories, defaults to best match",
+            "enum": [
+              "comments",
+              "reactions",
+              "reactions-+1",
+              "reactions--1",
+              "reactions-smile",
+              "reactions-thinking_face",
+              "reactions-heart",
+              "reactions-tada",
+              "interactions",
+              "created",
+              "updated"
+            ]
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "search_repositories",
+        "maps_to": "tool:search_repositories",
+        "description": "Find GitHub repositories by name, description, readme, topics, or other metadata. Perfect for discovering projects, finding examples, or locating specific repositories across GitHub.",
+        "params": {
+          "minimal_output": {
+            "type": "boolean",
+            "description": "Return minimal repository information (default: true). When false, returns full GitHub API repository objects.",
+            "default": true
+          },
+          "order": {
+            "type": "string",
+            "description": "Sort order",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "query": {
+            "type": "string",
+            "required": true,
+            "description": "Repository search query. Examples: 'machine learning in:name stars:>1000 language:python', 'topic:react', 'user:facebook'. Supports advanced search syntax for precise filtering."
+          },
+          "sort": {
+            "type": "string",
+            "description": "Sort repositories by field, defaults to best match",
+            "enum": [
+              "stars",
+              "forks",
+              "help-wanted-issues",
+              "updated"
+            ]
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "search_users",
+        "maps_to": "tool:search_users",
+        "description": "Find GitHub users by username, real name, or other profile information. Useful for locating developers, contributors, or team members.",
+        "params": {
+          "order": {
+            "type": "string",
+            "description": "Sort order",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (min 1)",
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page for pagination (min 1, max 100)",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "query": {
+            "type": "string",
+            "required": true,
+            "description": "User search query. Examples: 'john smith', 'location:seattle', 'followers:>100'. Search is automatically scoped to type:user."
+          },
+          "sort": {
+            "type": "string",
+            "description": "Sort users by number of followers or repositories, or when the person joined GitHub.",
+            "enum": [
+              "followers",
+              "repositories",
+              "joined"
+            ]
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "safe",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      }
+    ],
+    "create": [
+      {
+        "name": "add_comment_to_pending_review",
+        "maps_to": "tool:add_comment_to_pending_review",
+        "description": "Add review comment to the requester's latest pending pull request review. A pending review needs to already exist to call this (check with the user if not sure).",
+        "params": {
+          "body": {
+            "type": "string",
+            "required": true,
+            "description": "The text of the review comment"
+          },
+          "line": {
+            "type": "number",
+            "description": "The line of the blob in the pull request diff that the comment applies to. For multi-line comments, the last line of the range"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "path": {
+            "type": "string",
+            "required": true,
+            "description": "The relative path to the file that necessitates a comment"
+          },
+          "pull_number": {
+            "type": "number",
+            "required": true,
+            "description": "Pull request number"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "side": {
+            "type": "string",
+            "description": "The side of the diff to comment on. LEFT indicates the previous state, RIGHT indicates the new state",
+            "enum": [
+              "LEFT",
+              "RIGHT"
+            ]
+          },
+          "start_line": {
+            "type": "number",
+            "description": "For multi-line comments, the first line of the range that the comment applies to"
+          },
+          "start_side": {
+            "type": "string",
+            "description": "For multi-line comments, the starting side of the diff that the comment applies to. LEFT indicates the previous state, RIGHT indicates the new state",
+            "enum": [
+              "LEFT",
+              "RIGHT"
+            ]
+          },
+          "subject_type": {
+            "type": "string",
+            "required": true,
+            "description": "The level at which the comment is targeted",
+            "enum": [
+              "FILE",
+              "LINE"
+            ]
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "add_issue_comment",
+        "maps_to": "tool:add_issue_comment",
+        "description": "Add a comment to a specific issue in a GitHub repository. Use this tool to add comments to pull requests as well (in this case pass pull request number as issue_number), but only if user is not asking specifically to add review comments.",
+        "params": {
+          "body": {
+            "type": "string",
+            "required": true,
+            "description": "Comment content"
+          },
+          "issue_number": {
+            "type": "number",
+            "required": true,
+            "description": "Issue number to comment on"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "add_reply_to_pull_request_comment",
+        "maps_to": "tool:add_reply_to_pull_request_comment",
+        "description": "Add a reply to an existing pull request comment. This creates a new comment that is linked as a reply to the specified comment.",
+        "params": {
+          "body": {
+            "type": "string",
+            "required": true,
+            "description": "The text of the reply"
+          },
+          "comment_id": {
+            "type": "number",
+            "required": true,
+            "description": "The ID of the comment to reply to"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "pull_number": {
+            "type": "number",
+            "required": true,
+            "description": "Pull request number"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "assign_copilot_to_issue",
+        "maps_to": "tool:assign_copilot_to_issue",
+        "description": "Assign Copilot to a specific issue in a GitHub repository.\n\nThis tool can help with the following outcomes:\n- a Pull Request created with source code changes to resolve the issue\n\n\nMore information can be found at:\n- https://docs.github.com/en/copilot/using-github-copilot/using-copilot-coding-agent-to-work-on-tasks/about-assigning-tasks-to-copilot\n",
+        "params": {
+          "base_ref": {
+            "type": "string",
+            "description": "Git reference (e.g., branch) that the agent will start its work from. If not specified, defaults to the repository's default branch"
+          },
+          "custom_instructions": {
+            "type": "string",
+            "description": "Optional custom instructions to guide the agent beyond the issue body. Use this to provide additional context, constraints, or guidance that is not captured in the issue description"
+          },
+          "issue_number": {
+            "type": "number",
+            "required": true,
+            "description": "Issue number"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "create_branch",
+        "maps_to": "tool:create_branch",
+        "description": "Create a new branch in a GitHub repository",
+        "params": {
+          "branch": {
+            "type": "string",
+            "required": true,
+            "description": "Name for new branch"
+          },
+          "from_branch": {
+            "type": "string",
+            "description": "Source branch (defaults to repo default)"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "create_pull_request",
+        "maps_to": "tool:create_pull_request",
+        "description": "Create a new pull request in a GitHub repository.",
+        "params": {
+          "base": {
+            "type": "string",
+            "required": true,
+            "description": "Branch to merge into"
+          },
+          "body": {
+            "type": "string",
+            "description": "PR description"
+          },
+          "draft": {
+            "type": "boolean",
+            "description": "Create as draft PR"
+          },
+          "head": {
+            "type": "string",
+            "required": true,
+            "description": "Branch containing changes"
+          },
+          "maintainer_can_modify": {
+            "type": "boolean",
+            "description": "Allow maintainer edits"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "title": {
+            "type": "string",
+            "required": true,
+            "description": "PR title"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "create_repository",
+        "maps_to": "tool:create_repository",
+        "description": "Create a new GitHub repository in your account or specified organization",
+        "params": {
+          "auto_init": {
+            "type": "boolean",
+            "description": "Initialize with README"
+          },
+          "description": {
+            "type": "string",
+            "description": "Repository description"
+          },
+          "name": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "organization": {
+            "type": "string",
+            "description": "Organization to create the repository in (omit to create in your personal account)"
+          },
+          "private": {
+            "type": "boolean",
+            "description": "Whether repo should be private"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "fork_repository",
+        "maps_to": "tool:fork_repository",
+        "description": "Fork a GitHub repository to your account or specified organization",
+        "params": {
+          "organization": {
+            "type": "string",
+            "description": "Organization to fork to"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      }
+    ],
+    "update": [
+      {
+        "name": "create_or_update_file",
+        "maps_to": "tool:create_or_update_file",
+        "description": "Create or update a single file in a GitHub repository. \nIf updating, you should provide the SHA of the file you want to update. Use this tool to create or update a file in a GitHub repository remotely; do not use it for local file operations.\n\nIn order to obtain the SHA of original file version before updating, use the following git command:\ngit rev-parse <branch>:<path to file>\n\nSHA MUST be provided for existing file updates.\n",
+        "params": {
+          "branch": {
+            "type": "string",
+            "required": true,
+            "description": "Branch to create/update the file in"
+          },
+          "content": {
+            "type": "string",
+            "required": true,
+            "description": "Content of the file"
+          },
+          "message": {
+            "type": "string",
+            "required": true,
+            "description": "Commit message"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner (username or organization)"
+          },
+          "path": {
+            "type": "string",
+            "required": true,
+            "description": "Path where to create/update the file"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "sha": {
+            "type": "string",
+            "description": "The blob SHA of the file being replaced. Required if the file already exists."
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "issue_write",
+        "maps_to": "tool:issue_write",
+        "description": "Create a new or update an existing issue in a GitHub repository.",
+        "params": {
+          "assignees": {
+            "type": "array",
+            "description": "Usernames to assign to this issue"
+          },
+          "body": {
+            "type": "string",
+            "description": "Issue body content"
+          },
+          "duplicate_of": {
+            "type": "number",
+            "description": "Issue number that this issue is a duplicate of. Only used when state_reason is 'duplicate'."
+          },
+          "issue_number": {
+            "type": "number",
+            "description": "Issue number to update"
+          },
+          "labels": {
+            "type": "array",
+            "description": "Labels to apply to this issue"
+          },
+          "method": {
+            "type": "string",
+            "required": true,
+            "description": "Write operation to perform on a single issue.\nOptions are:\n- 'create' - creates a new issue.\n- 'update' - updates an existing issue.\n",
+            "enum": [
+              "create",
+              "update"
+            ]
+          },
+          "milestone": {
+            "type": "number",
+            "description": "Milestone number"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "state": {
+            "type": "string",
+            "description": "New state",
+            "enum": [
+              "open",
+              "closed"
+            ]
+          },
+          "state_reason": {
+            "type": "string",
+            "description": "Reason for the state change. Ignored unless state is changed.",
+            "enum": [
+              "completed",
+              "not_planned",
+              "duplicate"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "description": "Issue title"
+          },
+          "type": {
+            "type": "string",
+            "description": "Type of this issue. Only use if the repository has issue types configured. Use list_issue_types tool to get valid type values for the organization. If the repository doesn't support issue types, omit this parameter."
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "pull_request_review_write",
+        "maps_to": "tool:pull_request_review_write",
+        "description": "Create and/or submit, delete review of a pull request.\n\nAvailable methods:\n- create: Create a new review of a pull request. If \"event\" parameter is provided, the review is submitted. If \"event\" is omitted, a pending review is created.\n- submit_pending: Submit an existing pending review of a pull request. This requires that a pending review exists for the current user on the specified pull request. The \"body\" and \"event\" parameters are used when submitting the review.\n- delete_pending: Delete an existing pending review of a pull request. This requires that a pending review exists for the current user on the specified pull request.\n",
+        "params": {
+          "body": {
+            "type": "string",
+            "description": "Review comment text"
+          },
+          "commit_id": {
+            "type": "string",
+            "description": "SHA of commit to review"
+          },
+          "event": {
+            "type": "string",
+            "description": "Review action to perform.",
+            "enum": [
+              "APPROVE",
+              "REQUEST_CHANGES",
+              "COMMENT"
+            ]
+          },
+          "method": {
+            "type": "string",
+            "required": true,
+            "description": "The write operation to perform on pull request review.",
+            "enum": [
+              "create",
+              "submit_pending",
+              "delete_pending"
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "pull_number": {
+            "type": "number",
+            "required": true,
+            "description": "Pull request number"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "sub_issue_write",
+        "maps_to": "tool:sub_issue_write",
+        "description": "Add a sub-issue to a parent issue in a GitHub repository.",
+        "params": {
+          "after_id": {
+            "type": "number",
+            "description": "The ID of the sub-issue to be prioritized after (either after_id OR before_id should be specified)"
+          },
+          "before_id": {
+            "type": "number",
+            "description": "The ID of the sub-issue to be prioritized before (either after_id OR before_id should be specified)"
+          },
+          "issue_number": {
+            "type": "number",
+            "required": true,
+            "description": "The number of the parent issue"
+          },
+          "method": {
+            "type": "string",
+            "required": true,
+            "description": "The action to perform on a single sub-issue\nOptions are:\n- 'add' - add a sub-issue to a parent issue in a GitHub repository.\n- 'remove' - remove a sub-issue from a parent issue in a GitHub repository.\n- 'reprioritize' - change the order of sub-issues within a parent issue in a GitHub repository. Use either 'after_id' or 'before_id' to specify the new position.\n\t\t\t\t"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "replace_parent": {
+            "type": "boolean",
+            "description": "When true, replaces the sub-issue's current parent issue. Use with 'add' method only."
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "sub_issue_id": {
+            "type": "number",
+            "required": true,
+            "description": "The ID of the sub-issue to add. ID is not the same as issue number"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "update_pull_request",
+        "maps_to": "tool:update_pull_request",
+        "description": "Update an existing pull request in a GitHub repository.",
+        "params": {
+          "base": {
+            "type": "string",
+            "description": "New base branch name"
+          },
+          "body": {
+            "type": "string",
+            "description": "New description"
+          },
+          "draft": {
+            "type": "boolean",
+            "description": "Mark pull request as draft (true) or ready for review (false)"
+          },
+          "maintainer_can_modify": {
+            "type": "boolean",
+            "description": "Allow maintainer edits"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "pull_number": {
+            "type": "number",
+            "required": true,
+            "description": "Pull request number to update"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          },
+          "reviewers": {
+            "type": "array",
+            "description": "GitHub usernames to request reviews from"
+          },
+          "state": {
+            "type": "string",
+            "description": "New state",
+            "enum": [
+              "open",
+              "closed"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "description": "New title"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
+      {
+        "name": "update_pull_request_branch",
+        "maps_to": "tool:update_pull_request_branch",
+        "description": "Update the branch of a pull request with the latest changes from the base branch.",
+        "params": {
+          "expected_head_sha": {
+            "type": "string",
+            "description": "The expected SHA of the pull request's HEAD ref"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "pull_number": {
+            "type": "number",
+            "required": true,
+            "description": "Pull request number"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      }
+    ],
+    "execute": [
+      {
+        "name": "create_pull_request_with_copilot",
+        "maps_to": "tool:create_pull_request_with_copilot",
+        "description": "Delegate a task to GitHub Copilot coding agent to perform in the background. The agent will create a pull request with the implementation. You should use this tool if the user asks to create a pull request to perform a specific task, or if the user asks Copilot to do something.",
+        "params": {
+          "base_ref": {
+            "type": "string",
+            "description": "Git reference (e.g., branch) that the agent will start its work from. If not specified, defaults to the repository's default branch"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner. You can guess the owner, but confirm it with the user before proceeding."
+          },
+          "problem_statement": {
+            "type": "string",
+            "required": true,
+            "description": "Detailed description of the task to be performed (e.g., 'Implement a feature that does X', 'Fix bug Y', etc.)"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name. You can guess the repository name, but confirm it with the user before proceeding."
+          },
+          "title": {
+            "type": "string",
+            "required": true,
+            "description": "Title for the pull request that will be created"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": true
+      },
+      {
+        "name": "merge_pull_request",
+        "maps_to": "tool:merge_pull_request",
+        "description": "Merge a pull request in a GitHub repository.",
+        "params": {
+          "commit_message": {
+            "type": "string",
+            "description": "Extra detail for merge commit"
+          },
+          "commit_title": {
+            "type": "string",
+            "description": "Title for merge commit"
+          },
+          "merge_method": {
+            "type": "string",
+            "description": "Merge method",
+            "enum": [
+              "merge",
+              "squash",
+              "rebase"
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "pull_number": {
+            "type": "number",
+            "required": true,
+            "description": "Pull request number"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "dangerous",
+        "requires_confirmation": true,
+        "non_idempotent": true
+      },
+      {
+        "name": "push_files",
+        "maps_to": "tool:push_files",
+        "description": "Push multiple files to a GitHub repository in a single commit",
+        "params": {
+          "branch": {
+            "type": "string",
+            "required": true,
+            "description": "Branch to push to"
+          },
+          "files": {
+            "type": "array",
+            "required": true,
+            "description": "Array of file objects to push, each object with path (string) and content (string)"
+          },
+          "message": {
+            "type": "string",
+            "required": true,
+            "description": "Commit message"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "dangerous",
+        "requires_confirmation": true,
+        "non_idempotent": true
+      },
+      {
+        "name": "request_copilot_review",
+        "maps_to": "tool:request_copilot_review",
+        "description": "Request a GitHub Copilot code review for a pull request. Use this for automated feedback on pull requests, usually before requesting a human reviewer.",
+        "params": {
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "pull_number": {
+            "type": "number",
+            "required": true,
+            "description": "Pull request number"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "dangerous",
+        "requires_confirmation": true,
+        "non_idempotent": true
+      }
+    ],
+    "delete": [
+      {
+        "name": "delete_file",
+        "maps_to": "tool:delete_file",
+        "description": "Delete a file from a GitHub repository",
+        "params": {
+          "branch": {
+            "type": "string",
+            "required": true,
+            "description": "Branch to delete the file from"
+          },
+          "message": {
+            "type": "string",
+            "required": true,
+            "description": "Commit message"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner (username or organization)"
+          },
+          "path": {
+            "type": "string",
+            "required": true,
+            "description": "Path to the file to delete"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "destructive",
+        "requires_confirmation": true,
+        "non_idempotent": false
+      }
+    ]
+  }
+}

--- a/generated/github-mcp/schema/adapter-schema.json
+++ b/generated/github-mcp/schema/adapter-schema.json
@@ -1119,43 +1119,6 @@
         "non_idempotent": false
       },
       {
-        "name": "assign_copilot_to_issue",
-        "maps_to": "tool:assign_copilot_to_issue",
-        "description": "Assign Copilot to a specific issue in a GitHub repository.\n\nThis tool can help with the following outcomes:\n- a Pull Request created with source code changes to resolve the issue\n\n\nMore information can be found at:\n- https://docs.github.com/en/copilot/using-github-copilot/using-copilot-coding-agent-to-work-on-tasks/about-assigning-tasks-to-copilot\n",
-        "params": {
-          "base_ref": {
-            "type": "string",
-            "description": "Git reference (e.g., branch) that the agent will start its work from. If not specified, defaults to the repository's default branch"
-          },
-          "custom_instructions": {
-            "type": "string",
-            "description": "Optional custom instructions to guide the agent beyond the issue body. Use this to provide additional context, constraints, or guidance that is not captured in the issue description"
-          },
-          "issue_number": {
-            "type": "number",
-            "required": true,
-            "description": "Issue number"
-          },
-          "owner": {
-            "type": "string",
-            "required": true,
-            "description": "Repository owner"
-          },
-          "repo": {
-            "type": "string",
-            "required": true,
-            "description": "Repository name"
-          }
-        },
-        "response": {
-          "type": "object",
-          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
-        },
-        "danger_level": "reversible",
-        "requires_confirmation": false,
-        "non_idempotent": false
-      },
-      {
         "name": "create_branch",
         "maps_to": "tool:create_branch",
         "description": "Create a new branch in a GitHub repository",
@@ -1304,6 +1267,43 @@
       }
     ],
     "update": [
+      {
+        "name": "assign_copilot_to_issue",
+        "maps_to": "tool:assign_copilot_to_issue",
+        "description": "Assign Copilot to a specific issue in a GitHub repository.\n\nThis tool can help with the following outcomes:\n- a Pull Request created with source code changes to resolve the issue\n\n\nMore information can be found at:\n- https://docs.github.com/en/copilot/using-github-copilot/using-copilot-coding-agent-to-work-on-tasks/about-assigning-tasks-to-copilot\n",
+        "params": {
+          "base_ref": {
+            "type": "string",
+            "description": "Git reference (e.g., branch) that the agent will start its work from. If not specified, defaults to the repository's default branch"
+          },
+          "custom_instructions": {
+            "type": "string",
+            "description": "Optional custom instructions to guide the agent beyond the issue body. Use this to provide additional context, constraints, or guidance that is not captured in the issue description"
+          },
+          "issue_number": {
+            "type": "number",
+            "required": true,
+            "description": "Issue number"
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "reversible",
+        "requires_confirmation": false,
+        "non_idempotent": false
+      },
       {
         "name": "create_or_update_file",
         "maps_to": "tool:create_or_update_file",
@@ -1486,8 +1486,8 @@
           "type": "object",
           "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
         },
-        "danger_level": "reversible",
-        "requires_confirmation": false,
+        "danger_level": "destructive",
+        "requires_confirmation": true,
         "non_idempotent": false
       },
       {
@@ -1774,6 +1774,35 @@
             "type": "number",
             "required": true,
             "description": "Pull request number"
+          },
+          "repo": {
+            "type": "string",
+            "required": true,
+            "description": "Repository name"
+          }
+        },
+        "response": {
+          "type": "object",
+          "description": "Wrapped upstream MCP tool result preserving content and structured payloads."
+        },
+        "danger_level": "dangerous",
+        "requires_confirmation": true,
+        "non_idempotent": true
+      },
+      {
+        "name": "run_secret_scanning",
+        "maps_to": "tool:run_secret_scanning",
+        "description": "Scan files, content, or recent changes for secrets such as API keys, passwords, tokens, and credentials.\n\nThis tool is intended for targeted scans of specific files, snippets, or diffs provided directly as content. It accepts file contents or diffs and returns detected secrets with their locations and related secret scanning metadata. Content must not be empty. For full repository scanning, other mechanisms are available.\n\nCaveats:\n\n- Only files within the codebase should be scanned. Files outside of the codebase should not be sent.\n- Files listed in .gitignore should be skipped.",
+        "params": {
+          "files": {
+            "type": "array",
+            "required": true,
+            "description": "Array of file contents, snippets, or diff hunks to scan for secrets. These must be raw contents, not repository file paths."
+          },
+          "owner": {
+            "type": "string",
+            "required": true,
+            "description": "Repository owner"
           },
           "repo": {
             "type": "string",

--- a/generated/github-mcp/schema/schema-build-report.json
+++ b/generated/github-mcp/schema/schema-build-report.json
@@ -1,0 +1,616 @@
+{
+  "warnings": [
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'pullNumber' was normalized to 'pull_number'.",
+      "tool": "add_comment_to_pending_review",
+      "field": "pullNumber",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'startLine' was normalized to 'start_line'.",
+      "tool": "add_comment_to_pending_review",
+      "field": "startLine",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'startSide' was normalized to 'start_side'.",
+      "tool": "add_comment_to_pending_review",
+      "field": "startSide",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'subjectType' was normalized to 'subject_type'.",
+      "tool": "add_comment_to_pending_review",
+      "field": "subjectType",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'commentId' was normalized to 'comment_id'.",
+      "tool": "add_reply_to_pull_request_comment",
+      "field": "commentId",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'pullNumber' was normalized to 'pull_number'.",
+      "tool": "add_reply_to_pull_request_comment",
+      "field": "pullNumber",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "REVIEW_REQUIRED",
+      "severity": "warning",
+      "message": "Tool name spans both create and update semantics.",
+      "tool": "create_or_update_file",
+      "heuristic": "endpoint_classification"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'autoInit' was normalized to 'auto_init'.",
+      "tool": "create_repository",
+      "field": "autoInit",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'perPage' was normalized to 'per_page'.",
+      "tool": "get_commit",
+      "field": "perPage",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'perPage' was normalized to 'per_page'.",
+      "tool": "issue_read",
+      "field": "perPage",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "REVIEW_REQUIRED",
+      "severity": "info",
+      "message": "Write suffix is semantically broad and may hide create/update behavior.",
+      "tool": "issue_write",
+      "heuristic": "endpoint_classification"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'perPage' was normalized to 'per_page'.",
+      "tool": "list_branches",
+      "field": "perPage",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'perPage' was normalized to 'per_page'.",
+      "tool": "list_commits",
+      "field": "perPage",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'orderBy' was normalized to 'order_by'.",
+      "tool": "list_issues",
+      "field": "orderBy",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'perPage' was normalized to 'per_page'.",
+      "tool": "list_issues",
+      "field": "perPage",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'perPage' was normalized to 'per_page'.",
+      "tool": "list_pull_requests",
+      "field": "perPage",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'perPage' was normalized to 'per_page'.",
+      "tool": "list_releases",
+      "field": "perPage",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'perPage' was normalized to 'per_page'.",
+      "tool": "list_tags",
+      "field": "perPage",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "REVIEW_REQUIRED",
+      "severity": "info",
+      "message": "Action-oriented tool classified as EXECUTE conservatively.",
+      "tool": "merge_pull_request",
+      "heuristic": "endpoint_classification"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'pullNumber' was normalized to 'pull_number'.",
+      "tool": "merge_pull_request",
+      "field": "pullNumber",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'perPage' was normalized to 'per_page'.",
+      "tool": "pull_request_read",
+      "field": "perPage",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'pullNumber' was normalized to 'pull_number'.",
+      "tool": "pull_request_read",
+      "field": "pullNumber",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "REVIEW_REQUIRED",
+      "severity": "info",
+      "message": "Write suffix is semantically broad and may hide create/update behavior.",
+      "tool": "pull_request_review_write",
+      "heuristic": "endpoint_classification"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'commitID' was normalized to 'commit_id'.",
+      "tool": "pull_request_review_write",
+      "field": "commitID",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'pullNumber' was normalized to 'pull_number'.",
+      "tool": "pull_request_review_write",
+      "field": "pullNumber",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "REVIEW_REQUIRED",
+      "severity": "info",
+      "message": "Action-oriented tool classified as EXECUTE conservatively.",
+      "tool": "push_files",
+      "heuristic": "endpoint_classification"
+    },
+    {
+      "code": "REVIEW_REQUIRED",
+      "severity": "info",
+      "message": "Action-oriented tool classified as EXECUTE conservatively.",
+      "tool": "request_copilot_review",
+      "heuristic": "endpoint_classification"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'pullNumber' was normalized to 'pull_number'.",
+      "tool": "request_copilot_review",
+      "field": "pullNumber",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'perPage' was normalized to 'per_page'.",
+      "tool": "search_code",
+      "field": "perPage",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'perPage' was normalized to 'per_page'.",
+      "tool": "search_issues",
+      "field": "perPage",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'perPage' was normalized to 'per_page'.",
+      "tool": "search_pull_requests",
+      "field": "perPage",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'perPage' was normalized to 'per_page'.",
+      "tool": "search_repositories",
+      "field": "perPage",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'perPage' was normalized to 'per_page'.",
+      "tool": "search_users",
+      "field": "perPage",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "REVIEW_REQUIRED",
+      "severity": "info",
+      "message": "Write suffix is semantically broad and may hide create/update behavior.",
+      "tool": "sub_issue_write",
+      "heuristic": "endpoint_classification"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'pullNumber' was normalized to 'pull_number'.",
+      "tool": "update_pull_request",
+      "field": "pullNumber",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'expectedHeadSha' was normalized to 'expected_head_sha'.",
+      "tool": "update_pull_request_branch",
+      "field": "expectedHeadSha",
+      "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "PARAM_NAME_NORMALIZED",
+      "severity": "info",
+      "message": "Parameter 'pullNumber' was normalized to 'pull_number'.",
+      "tool": "update_pull_request_branch",
+      "field": "pullNumber",
+      "heuristic": "snake_case_normalization"
+    }
+  ],
+  "operations": [
+    {
+      "source_tool_name": "add_comment_to_pending_review",
+      "operation_name": "add_comment_to_pending_review",
+      "endpoint": "CREATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "add_issue_comment",
+      "operation_name": "add_issue_comment",
+      "endpoint": "CREATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "add_reply_to_pull_request_comment",
+      "operation_name": "add_reply_to_pull_request_comment",
+      "endpoint": "CREATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "assign_copilot_to_issue",
+      "operation_name": "assign_copilot_to_issue",
+      "endpoint": "CREATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "create_branch",
+      "operation_name": "create_branch",
+      "endpoint": "CREATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "create_or_update_file",
+      "operation_name": "create_or_update_file",
+      "endpoint": "UPDATE",
+      "needs_review": true,
+      "review_reasons": [
+        "Tool name spans both create and update semantics.",
+        "Mixed create/update semantics mapped to UPDATE for the first generated adapter."
+      ]
+    },
+    {
+      "source_tool_name": "create_pull_request",
+      "operation_name": "create_pull_request",
+      "endpoint": "CREATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "create_pull_request_with_copilot",
+      "operation_name": "create_pull_request_with_copilot",
+      "endpoint": "EXECUTE",
+      "needs_review": false,
+      "review_reasons": [
+        "Copilot-assisted pull request creation is treated as workflow execution in the first pass."
+      ]
+    },
+    {
+      "source_tool_name": "create_repository",
+      "operation_name": "create_repository",
+      "endpoint": "CREATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "delete_file",
+      "operation_name": "delete_file",
+      "endpoint": "DELETE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "fork_repository",
+      "operation_name": "fork_repository",
+      "endpoint": "CREATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_commit",
+      "operation_name": "get_commit",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_copilot_job_status",
+      "operation_name": "get_copilot_job_status",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_file_contents",
+      "operation_name": "get_file_contents",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_label",
+      "operation_name": "get_label",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_latest_release",
+      "operation_name": "get_latest_release",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_me",
+      "operation_name": "get_me",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_release_by_tag",
+      "operation_name": "get_release_by_tag",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_tag",
+      "operation_name": "get_tag",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_team_members",
+      "operation_name": "get_team_members",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "get_teams",
+      "operation_name": "get_teams",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "issue_read",
+      "operation_name": "issue_read",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "issue_write",
+      "operation_name": "issue_write",
+      "endpoint": "UPDATE",
+      "needs_review": true,
+      "review_reasons": [
+        "Write suffix is semantically broad and may hide create/update behavior.",
+        "issue_write spans create and update behavior; pinned to UPDATE pending finer-grained decomposition."
+      ]
+    },
+    {
+      "source_tool_name": "list_branches",
+      "operation_name": "list_branches",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "list_commits",
+      "operation_name": "list_commits",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "list_issue_types",
+      "operation_name": "list_issue_types",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "list_issues",
+      "operation_name": "list_issues",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "list_pull_requests",
+      "operation_name": "list_pull_requests",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "list_releases",
+      "operation_name": "list_releases",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "list_tags",
+      "operation_name": "list_tags",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "merge_pull_request",
+      "operation_name": "merge_pull_request",
+      "endpoint": "EXECUTE",
+      "needs_review": true,
+      "review_reasons": [
+        "Action-oriented tool classified as EXECUTE conservatively."
+      ]
+    },
+    {
+      "source_tool_name": "pull_request_read",
+      "operation_name": "pull_request_read",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "pull_request_review_write",
+      "operation_name": "pull_request_review_write",
+      "endpoint": "UPDATE",
+      "needs_review": true,
+      "review_reasons": [
+        "Write suffix is semantically broad and may hide create/update behavior.",
+        "Review-write semantics are treated as UPDATE in the first pass."
+      ]
+    },
+    {
+      "source_tool_name": "push_files",
+      "operation_name": "push_files",
+      "endpoint": "EXECUTE",
+      "needs_review": true,
+      "review_reasons": [
+        "Action-oriented tool classified as EXECUTE conservatively."
+      ]
+    },
+    {
+      "source_tool_name": "request_copilot_review",
+      "operation_name": "request_copilot_review",
+      "endpoint": "EXECUTE",
+      "needs_review": true,
+      "review_reasons": [
+        "Action-oriented tool classified as EXECUTE conservatively."
+      ]
+    },
+    {
+      "source_tool_name": "search_code",
+      "operation_name": "search_code",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "search_issues",
+      "operation_name": "search_issues",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "search_pull_requests",
+      "operation_name": "search_pull_requests",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "search_repositories",
+      "operation_name": "search_repositories",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "search_users",
+      "operation_name": "search_users",
+      "endpoint": "READ",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "sub_issue_write",
+      "operation_name": "sub_issue_write",
+      "endpoint": "UPDATE",
+      "needs_review": true,
+      "review_reasons": [
+        "Write suffix is semantically broad and may hide create/update behavior.",
+        "sub_issue_write is treated as UPDATE until the source server exposes narrower tool semantics."
+      ]
+    },
+    {
+      "source_tool_name": "update_pull_request",
+      "operation_name": "update_pull_request",
+      "endpoint": "UPDATE",
+      "needs_review": false,
+      "review_reasons": []
+    },
+    {
+      "source_tool_name": "update_pull_request_branch",
+      "operation_name": "update_pull_request_branch",
+      "endpoint": "UPDATE",
+      "needs_review": false,
+      "review_reasons": []
+    }
+  ]
+}

--- a/generated/github-mcp/schema/schema-build-report.json
+++ b/generated/github-mcp/schema/schema-build-report.json
@@ -541,7 +541,8 @@
       "endpoint": "EXECUTE",
       "needs_review": true,
       "review_reasons": [
-        "Action-oriented tool classified as EXECUTE conservatively."
+        "Action-oriented tool classified as EXECUTE conservatively.",
+        "push_files can create and update multiple files plus branch history in a single workflow, so the first golden-path adapter keeps it in EXECUTE rather than collapsing it into CREATE or UPDATE."
       ]
     },
     {

--- a/generated/github-mcp/schema/schema-build-report.json
+++ b/generated/github-mcp/schema/schema-build-report.json
@@ -50,6 +50,13 @@
     },
     {
       "code": "REVIEW_REQUIRED",
+      "severity": "info",
+      "message": "Assignment semantics treated as UPDATE on an existing resource.",
+      "tool": "assign_copilot_to_issue",
+      "heuristic": "endpoint_classification"
+    },
+    {
+      "code": "REVIEW_REQUIRED",
       "severity": "warning",
       "message": "Tool name spans both create and update semantics.",
       "tool": "create_or_update_file",
@@ -176,7 +183,7 @@
     {
       "code": "REVIEW_REQUIRED",
       "severity": "info",
-      "message": "Write suffix is semantically broad and may hide create/update behavior.",
+      "message": "Description implies destructive behavior.",
       "tool": "pull_request_review_write",
       "heuristic": "endpoint_classification"
     },
@@ -217,6 +224,13 @@
       "tool": "request_copilot_review",
       "field": "pullNumber",
       "heuristic": "snake_case_normalization"
+    },
+    {
+      "code": "REVIEW_REQUIRED",
+      "severity": "info",
+      "message": "Description implies workflow execution.",
+      "tool": "run_secret_scanning",
+      "heuristic": "endpoint_classification"
     },
     {
       "code": "PARAM_NAME_NORMALIZED",
@@ -315,9 +329,11 @@
     {
       "source_tool_name": "assign_copilot_to_issue",
       "operation_name": "assign_copilot_to_issue",
-      "endpoint": "CREATE",
-      "needs_review": false,
-      "review_reasons": []
+      "endpoint": "UPDATE",
+      "needs_review": true,
+      "review_reasons": [
+        "Assignment semantics treated as UPDATE on an existing resource."
+      ]
     },
     {
       "source_tool_name": "create_branch",
@@ -531,7 +547,7 @@
       "endpoint": "UPDATE",
       "needs_review": true,
       "review_reasons": [
-        "Write suffix is semantically broad and may hide create/update behavior.",
+        "Description implies destructive behavior.",
         "Review-write semantics are treated as UPDATE in the first pass."
       ]
     },
@@ -552,6 +568,15 @@
       "needs_review": true,
       "review_reasons": [
         "Action-oriented tool classified as EXECUTE conservatively."
+      ]
+    },
+    {
+      "source_tool_name": "run_secret_scanning",
+      "operation_name": "run_secret_scanning",
+      "endpoint": "EXECUTE",
+      "needs_review": true,
+      "review_reasons": [
+        "Description implies workflow execution."
       ]
     },
     {

--- a/generated/github-mcp/server-config.json
+++ b/generated/github-mcp/server-config.json
@@ -1,0 +1,13 @@
+{
+  "name": "github-mcp-remote",
+  "server_url": "https://api.githubcopilot.com/mcp/",
+  "transport": {
+    "type": "streamable_http"
+  },
+  "auth": {
+    "type": "bearer",
+    "token_command": "gh auth token",
+    "header": "Authorization",
+    "prefix": "Bearer "
+  }
+}

--- a/generated/github-mcp/validation/README.md
+++ b/generated/github-mcp/validation/README.md
@@ -1,0 +1,20 @@
+# Validation Reports
+
+This directory stores the saved validation outputs for the generated GitHub MCP adapter.
+
+- `conformance-report.json` checks that the generated adapter exposes the expected MCP-AQL tool surface and that its request, result, and introspection envelopes validate against the current spec schemas.
+- `differential-report.json` compares the generated adapter's introspection surface to the captured GitHub MCP discovery bundle and finalized adapter schema.
+
+## Notes
+
+- `adapter_operation_count` is expected to be one higher than `source_operation_count` because the generated adapter injects a synthetic `introspect` operation.
+- `missing_operations` and `extra_operations` intentionally exclude that synthetic `introspect` operation so the parity report focuses on wrapped upstream behavior.
+
+## Re-running
+
+From `generated/github-mcp/`, regenerate the saved reports with:
+
+```bash
+node ../../../tools/dist/conformance-cli.js --command node --args "[\"dist/server.js\"]" --cwd adapter --schema-root ../../../spec/schemas > validation/conformance-report.json
+node ../../../tools/dist/diff-cli.js --bundle capture/discovery-bundle.json --schema schema/adapter-schema.json --command node --args "[\"dist/server.js\"]" --cwd adapter > validation/differential-report.json
+```

--- a/generated/github-mcp/validation/conformance-report.json
+++ b/generated/github-mcp/validation/conformance-report.json
@@ -1,0 +1,25 @@
+{
+  "passed": true,
+  "checks": [
+    {
+      "name": "tool-registration",
+      "passed": true,
+      "detail": "Registered tools: mcp_aql_read, mcp_aql_create, mcp_aql_update, mcp_aql_execute, mcp_aql_delete"
+    },
+    {
+      "name": "operation-input-schema",
+      "passed": true,
+      "detail": "Request matches schema."
+    },
+    {
+      "name": "operation-result-schema",
+      "passed": true,
+      "detail": "Response envelope matches schema."
+    },
+    {
+      "name": "introspection-response-schema",
+      "passed": true,
+      "detail": "Introspection response matches schema."
+    }
+  ]
+}

--- a/generated/github-mcp/validation/differential-report.json
+++ b/generated/github-mcp/validation/differential-report.json
@@ -3,7 +3,10 @@
     "source_operation_count": 43,
     "adapter_operation_count": 44,
     "missing_operations": [],
-    "extra_operations": []
+    "extra_operations": [],
+    "notes": [
+      "adapter_operation_count includes 1 synthetic adapter operation(s): introspect."
+    ]
   },
   "operations": [
     {

--- a/generated/github-mcp/validation/differential-report.json
+++ b/generated/github-mcp/validation/differential-report.json
@@ -1,7 +1,7 @@
 {
   "summary": {
-    "source_operation_count": 43,
-    "adapter_operation_count": 44,
+    "source_operation_count": 44,
+    "adapter_operation_count": 45,
     "missing_operations": [],
     "extra_operations": [],
     "notes": [
@@ -199,13 +199,6 @@
       "extra_parameters": []
     },
     {
-      "operation": "assign_copilot_to_issue",
-      "endpoint_match": true,
-      "parameter_names_match": true,
-      "missing_parameters": [],
-      "extra_parameters": []
-    },
-    {
       "operation": "create_branch",
       "endpoint_match": true,
       "parameter_names_match": true,
@@ -228,6 +221,13 @@
     },
     {
       "operation": "fork_repository",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "assign_copilot_to_issue",
       "endpoint_match": true,
       "parameter_names_match": true,
       "missing_parameters": [],
@@ -298,6 +298,13 @@
     },
     {
       "operation": "request_copilot_review",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "run_secret_scanning",
       "endpoint_match": true,
       "parameter_names_match": true,
       "missing_parameters": [],

--- a/generated/github-mcp/validation/differential-report.json
+++ b/generated/github-mcp/validation/differential-report.json
@@ -1,0 +1,311 @@
+{
+  "summary": {
+    "source_operation_count": 43,
+    "adapter_operation_count": 44,
+    "missing_operations": [],
+    "extra_operations": []
+  },
+  "operations": [
+    {
+      "operation": "get_commit",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "get_copilot_job_status",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "get_file_contents",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "get_label",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "get_latest_release",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "get_me",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "get_release_by_tag",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "get_tag",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "get_team_members",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "get_teams",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "issue_read",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "list_branches",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "list_commits",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "list_issue_types",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "list_issues",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "list_pull_requests",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "list_releases",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "list_tags",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "pull_request_read",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "search_code",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "search_issues",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "search_pull_requests",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "search_repositories",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "search_users",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "add_comment_to_pending_review",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "add_issue_comment",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "add_reply_to_pull_request_comment",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "assign_copilot_to_issue",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "create_branch",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "create_pull_request",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "create_repository",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "fork_repository",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "create_or_update_file",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "issue_write",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "pull_request_review_write",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "sub_issue_write",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "update_pull_request",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "update_pull_request_branch",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "create_pull_request_with_copilot",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "merge_pull_request",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "push_files",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "request_copilot_review",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    },
+    {
+      "operation": "delete_file",
+      "endpoint_match": true,
+      "parameter_names_match": true,
+      "missing_parameters": [],
+      "extra_parameters": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add the GitHub MCP server capture artifacts and normalized discovery bundle
- add the generated adapter schema, provenance, and runnable adapter package
- add saved conformance and differential validation reports and document the flow

## Why
This checks in the first complete golden-path example so the new spec, tooling, and generator work can be reviewed against a concrete end-to-end output.

## Validation
- saved conformance report passes
- saved differential report shows no missing or extra wrapped operations

Refs: #11