### PR TITLE
Re-enable public cross-repo link checks

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -26,8 +26,8 @@ exclude = [
     "^https?://mcpaql\\.org",
     "^https?://spec\\.modelcontextprotocol\\.io",
 
-    # MCPAQL GitHub repos (private, return 404 from CI)
-    "^https?://github\\.com/MCPAQL/",
+    # MCPAQL GitHub repos that are still private
+    "^https?://github\\.com/MCPAQL/mcpaql-adapter(?:[/?#].*)?$",
 
     # DollhouseMCP development repo (historical references, may be private)
     "^https?://github\\.com/DollhouseMCP/mcp-server-v2-refactor",

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -26,9 +26,6 @@ exclude = [
     "^https?://mcpaql\\.org",
     "^https?://spec\\.modelcontextprotocol\\.io",
 
-    # MCPAQL GitHub repos that are still private
-    "^https?://github\\.com/MCPAQL/mcpaql-adapter(?:[/?#].*)?$",
-
     # DollhouseMCP development repo (historical references, may be private)
     "^https?://github\\.com/DollhouseMCP/mcp-server-v2-refactor",
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Link checking for public MCPAQL repos
-  - Narrowed the lychee GitHub exclusion so `spec` and `adapter-generator` links are checked now that those repositories are public
-  - Kept the `mcpaql-adapter` exclusion in place until that repository is public
+  - Removed the repo-wide GitHub exclusion from lychee now that `examples`, `spec`, `adapter-generator`, and `mcpaql-adapter` are all public
+  - Re-enabled CI link checking for the public cross-repo references used throughout the examples documentation
 - GitHub MCP golden-path public-readiness cleanup
   - Normalized the committed GitHub example to use env-var auth guidance instead of `gh auth token`
   - Refreshed saved capture, schema, adapter, and validation artifacts from the env-var-only auth path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Link checking for public MCPAQL repos
+  - Narrowed the lychee GitHub exclusion so `spec` and `adapter-generator` links are checked now that those repositories are public
+  - Kept the `mcpaql-adapter` exclusion in place until that repository is public
 - GitHub MCP golden-path public-readiness cleanup
   - Normalized the committed GitHub example to use env-var auth guidance instead of `gh auth token`
   - Refreshed saved capture, schema, adapter, and validation artifacts from the env-var-only auth path


### PR DESCRIPTION
## Summary

- narrow the lychee GitHub exclusion to the one MCPAQL repo that is still private
- start checking public links to spec and adapter-generator in CI
- keep the changelog aligned with the public-facing repo cleanup

## Context

Follow-up for issue #19 now that examples, spec, and adapter-generator are public while mcpaql-adapter is still private.

## Test plan

- [x] audited current github.com/MCPAQL/* links in the repo
- [x] narrowed .lychee.toml to exclude only mcpaql-adapter
- [ ] CI link-check passes on this branch
- [ ] Claude review