### PR TITLE
fix: claude review comment permission pattern

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -125,5 +125,6 @@ jobs:
             ### Verdict
             APPROVE, REQUEST_CHANGES, or COMMENT — with a brief justification.
 
+          show_full_output: true
           claude_args: |
-            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh api repos/*/pulls/*/comments*),Bash(gh api repos/*/issues/*/comments*),Read,Glob,Grep"
+            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh api repos/*/*/pulls/*/comments*),Bash(gh api repos/*/*/issues/*/comments*),Read,Glob,Grep"


### PR DESCRIPTION
## Summary
- Fix `gh api` glob pattern: `repos/*/pulls/*` → `repos/*/*/pulls/*`
- Enable `show_full_output: true` for debugging

## Test plan
- [ ] Re-run Claude review on an open PR and verify comment appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)