### PR TITLE
docs(airpods-mcp): prebuilt download section + post-release CHANGELOG sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This is a rolling examples collection and uses date-based versioning
+(`YYYY.MM.DD`) rather than Semantic Versioning.
 
 ## [Unreleased]
+
+## [2026.05.15] - 2026-05-15
 
 ### Added
 

--- a/generated/airpods-mcp/README.md
+++ b/generated/airpods-mcp/README.md
@@ -89,7 +89,31 @@ Pose units: radians. Convention: positive yaw = head turned **left**, positive p
 - Xcode command-line tools (for `swiftc`)
 - Node 20+
 
-### Build motion source (one-time)
+### Option A — download prebuilt binaries
+
+Prebuilt, ad-hoc-signed **Apple Silicon (arm64), macOS 14+** binaries are
+attached to each release:
+
+**https://github.com/MCPAQL/examples/releases/latest**
+
+- `airpods-mcp-server.app.zip` — the motion-source `.app`
+- `airpods-mcp-sidecar-binaries.tar.gz` — `window-at-point`, `dwell-blob`, `move-cursor`, `speak-pan`
+- `SHA256SUMS` — verify with `shasum -a 256 -c SHA256SUMS`
+
+They are quarantined on download (ad-hoc signed, not notarized — this is a
+showcase artifact). Clear it before first run:
+
+```sh
+xattr -dr com.apple.quarantine airpods-mcp-server.app
+xattr -dr com.apple.quarantine window-at-point dwell-blob move-cursor speak-pan
+```
+
+Node deps still need install (Option B step "Install Node dependencies").
+Intel Macs: build from source (Option B).
+
+### Option B — build from source
+
+#### Build motion source (one-time)
 
 ```sh
 cd server
@@ -99,9 +123,7 @@ cp Info.plist airpods-mcp-server.app/Contents/Info.plist
 codesign --force --sign - --identifier org.mcpaql.airpods-mcp airpods-mcp-server.app
 ```
 
-(Or use the prebuilt `airpods-mcp-server.app/` if it's already in the repo.)
-
-### Build sidecar Swift helpers (one-time)
+#### Build sidecar Swift helpers (one-time)
 
 ```sh
 cd sidecar
@@ -111,7 +133,7 @@ swiftc move-cursor.swift      -o move-cursor
 swiftc speak-pan.swift        -o speak-pan       -framework AVFoundation
 ```
 
-### Install Node dependencies (one-time)
+#### Install Node dependencies (one-time)
 
 The adapter and the sidecar are separate packages; each needs its own install.
 


### PR DESCRIPTION
## Summary

Post-release (`2026.05.15`) follow-up, two parts:

1. **CHANGELOG back-merge (Git Flow fix).** The release branch cut the CHANGELOG (`[Unreleased]` → `[2026.05.15]`, CalVer note) and that merged to `main` via #42, but the standard merge-back to `develop` was missing. Without this, develop keeps every entry under `[Unreleased]` and the next release double-counts. This adopts `main`'s CHANGELOG verbatim — code was already identical develop↔main, so the CHANGELOG was the only divergence.
2. **README prebuilt-download section.** Adds "Option A — download prebuilt binaries" pointing at https://github.com/MCPAQL/examples/releases/latest (arch = Apple Silicon/arm64, Gatekeeper `xattr` steps, `SHA256SUMS` verify) and nests the existing build steps under "Option B — build from source". Removes the stale line claiming binaries may be "in the repo" (they're gitignored; they ship via the release).

## Notes

- Spell Check red = the known pre-existing Node-20-vs-cspell-10 infra issue (separate `fix/*` PR is the next queued item), not introduced here.
- markdownlint: 0 errors locally.

## Test plan

- [ ] develop CHANGELOG matches main (empty `[Unreleased]`, populated `[2026.05.15]`)
- [ ] README "Option A" link resolves to the release; build steps intact under "Option B"

🤖 Generated with [Claude Code](https://claude.com/claude-code)